### PR TITLE
feat: add test-all skill for automated test discovery and execution

### DIFF
--- a/.claude/skills/test-all/SKILL.md
+++ b/.claude/skills/test-all/SKILL.md
@@ -36,9 +36,11 @@ git diff --name-only <base-branch>...HEAD 2>/dev/null || true
 git diff --name-only
 # Staged changes
 git diff --name-only --cached
+# Untracked files (new files not yet staged)
+git ls-files --others --exclude-standard
 ```
 
-Combine all changed file paths. Map each changed file to its parent service directory. A service directory is identified by the presence of a project manifest at its root:
+Combine all changed file paths (including untracked). Map each changed file to its parent service directory. A service directory is identified by the presence of a project manifest at its root:
 
 - `package.json` (Node.js / frontend)
 - `pyproject.toml` or `setup.py` or `setup.cfg` (Python)
@@ -62,7 +64,7 @@ For each affected service, scan for test runner configurations and classify test
 |---|---|---|
 | `jest.config.*` or `jest` key in package.json | Jest | unit |
 | `vitest.config.*` | Vitest | unit |
-| `pytest.ini` / `pyproject.toml` with `[tool.pytest]` / `conftest.py` | pytest | unit |
+| `pytest.ini` / `pyproject.toml` with `[tool.pytest.ini_options]` / `conftest.py` | pytest | unit |
 | `playwright.config.*` | Playwright | e2e |
 | `cypress.config.*` or `cypress/` directory | Cypress | e2e |
 | `.mocharc.*` or `mocha` key in package.json | Mocha | unit |
@@ -223,7 +225,7 @@ CHECKPOINT: 2/4 complete, 2 remaining:
 |---|---|
 | Jest | `npx jest --ci --coverage --no-color` |
 | Vitest | `npx vitest run --coverage --reporter=verbose` |
-| pytest | `python -m pytest -v --tb=short --no-header --cov` |
+| pytest | `python -m pytest -v --tb=short --no-header` (add `--cov` only if pytest-cov is installed) |
 | Playwright | `npx playwright test --reporter=list` |
 | Cypress | `npx cypress run --reporter spec` |
 | Mocha | `npx mocha --reporter spec --no-color` |
@@ -234,7 +236,7 @@ CHECKPOINT: 2/4 complete, 2 remaining:
 | Locust | `locust --headless -u 1 -r 1 --run-time 30s` |
 | dotnet test | `dotnet test --no-build --verbosity normal` |
 
-Note: `--no-header` requires pytest >= 7.0. For older versions, remove this flag from the command.
+Note: `--no-header` requires pytest >= 7.0. For older versions, remove this flag. To check if pytest-cov is available, run `python -m pytest --co -q --cov 2>&1 | head -1` -- if it errors with "unrecognized arguments", omit `--cov`.
 
 Use the command resolution priority from Step 2b: project-specific scripts first, then named package.json scripts, then standard runner commands from the table above.
 

--- a/.claude/skills/test-all/SKILL.md
+++ b/.claude/skills/test-all/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: test-all
+description: Detect modified services in a monorepo, discover all test types (unit, integration, component, e2e, performance), validate environment readiness, run tests, and produce a structured report. Use when you need to run all applicable tests after code changes.
+argument-hint: "[service-path or --all] [--base-branch=main]"
+allowed-tools: Task, Bash, Read, Write, Grep, Glob
+---
+
+# Test All
+
+## Goal
+
+Automatically detect changed services, discover all available test suites, validate environment readiness, execute tests, and produce a structured report.
+
+## Required Inputs
+
+Collect before execution:
+
+- Repository root path (default: current working directory)
+- Base branch for diff comparison (default: `main`, override with `--base-branch=<branch>`)
+- Scope: auto-detect from git changes, explicit service paths, or `--all` for full run
+
+If `$ARGUMENTS` contains paths, use those as explicit service targets.
+If `$ARGUMENTS` contains `--all`, scan every service in the monorepo.
+Otherwise, auto-detect affected services from git changes.
+
+## Workflow
+
+### 1. Detect Changed Services
+
+Identify which services have been modified:
+
+```bash
+# All changes in current branch vs base
+git diff --name-only <base-branch>...HEAD 2>/dev/null || true
+# Unstaged changes
+git diff --name-only
+# Staged changes
+git diff --name-only --cached
+```
+
+Combine all changed file paths. Map each changed file to its parent service directory. A service directory is identified by the presence of a project manifest at its root:
+
+- `package.json` (Node.js / frontend)
+- `pyproject.toml` or `setup.py` or `setup.cfg` (Python)
+- `go.mod` (Go)
+- `pom.xml` or `build.gradle` or `build.gradle.kts` (Java/Kotlin)
+- `Cargo.toml` (Rust)
+- `Gemfile` (Ruby)
+- `composer.json` (PHP)
+- `Makefile` with test targets (generic)
+
+If the repository root itself is a single-service project (manifest at root level), treat the entire repo as one service.
+
+Report the list of affected services with the count of changed files per service.
+
+### 2. Discover Test Configurations
+
+For each affected service, scan for test runner configurations and classify test types:
+
+| Marker | Runner | Default Type |
+|---|---|---|
+| `jest.config.*` or `jest` key in package.json | Jest | unit |
+| `vitest.config.*` | Vitest | unit |
+| `pytest.ini` / `pyproject.toml` with `[tool.pytest]` / `conftest.py` | pytest | unit |
+| `playwright.config.*` | Playwright | e2e |
+| `cypress.config.*` or `cypress/` directory | Cypress | e2e |
+| `.mocharc.*` or `mocha` key in package.json | Mocha | unit |
+| `*_test.go` files | go test | unit |
+| `src/test/` + `pom.xml` | Maven (JUnit) | unit |
+| `src/test/` + `build.gradle*` | Gradle (JUnit) | unit |
+| `k6/` scripts or `*.k6.js` | k6 | performance |
+| `locustfile.py` or `locust/` | Locust | performance |
+| `artillery.yml` or `.artillery/` | Artillery | performance |
+
+Additionally, check `package.json` scripts for named test commands:
+
+- `test` or `test:unit` -> unit
+- `test:integration` or `test:int` -> integration
+- `test:component` -> component
+- `test:e2e` or `test:playwright` or `test:cypress` -> e2e
+- `test:perf` or `test:performance` or `test:load` -> performance
+- `test:all` -> all types
+
+For Python projects, check for directory conventions:
+
+- `tests/unit/` or `tests/test_*.py` at root -> unit
+- `tests/integration/` -> integration
+- `tests/e2e/` -> e2e
+- `tests/performance/` or `tests/load/` -> performance
+
+For Go projects, check for:
+
+- `*_test.go` in source directories -> unit
+- `tests/integration/` or `_integration_test.go` suffix -> integration
+- `tests/e2e/` -> e2e
+
+Produce a matrix: service x test-type with runner commands.
+
+### 3. Validate Environment Readiness
+
+For each service, check prerequisites:
+
+**Node.js services:**
+- `node_modules/` exists -> if not, suggest `npm install` / `yarn install` / `pnpm install`
+- Check for lockfile to determine package manager (package-lock.json / yarn.lock / pnpm-lock.yaml)
+- `.env` or `.env.test` exists if referenced in configs
+
+**Python services:**
+- Virtual environment exists (`.venv/`, `venv/`, or active conda env)
+- Dependencies installed (check for `requirements.txt`, `pyproject.toml` with deps)
+- Test dependencies present (pytest in installed packages)
+
+**Go services:**
+- `go.sum` exists (modules downloaded)
+- Build succeeds (`go build ./...`)
+
+**Java/Kotlin services:**
+- Build tool wrapper exists (`mvnw`, `gradlew`)
+- Dependencies cached (`~/.m2/repository` or `.gradle/`)
+
+**Integration/E2E prerequisites:**
+- Docker running (if docker-compose.yml or Dockerfile present in test config)
+- Test database available (check env vars like DATABASE_URL, TEST_DATABASE_URL)
+- Required services running (check ports or health endpoints if configured)
+
+Classify each service:
+
+- `ready` - all prerequisites met, tests can run immediately
+- `needs-setup` - missing prerequisites with specific fix commands
+- `blocked` - critical dependency missing that cannot be auto-resolved
+
+If a service is `needs-setup`, ask the user whether to run setup commands before continuing.
+
+### 4. Run Tests
+
+Execute tests in priority order (fastest first):
+
+1. **Unit tests** - timeout 5 minutes per service
+2. **Integration tests** - timeout 10 minutes per service
+3. **Component tests** - timeout 10 minutes per service
+4. **E2E tests** - timeout 15 minutes per service
+5. **Performance tests** - timeout 10 minutes per service
+
+Execution rules:
+
+- For independent services, use Task tool to launch parallel subagents (one per service)
+- Within a service, run test types sequentially in the order above
+- Capture full stdout/stderr for each test run
+- Record exit code, duration, and any coverage output
+- If a test suite fails, continue with remaining suites in that service and other services
+- Pass `--no-color` or equivalent flag when available for clean output parsing
+- Use `--coverage` or equivalent when the runner supports it
+
+Common run commands by runner:
+
+| Runner | Command |
+|---|---|
+| Jest | `npx jest --ci --coverage --no-color` |
+| Vitest | `npx vitest run --coverage --reporter=verbose` |
+| pytest | `python -m pytest -v --tb=short --no-header` |
+| Playwright | `npx playwright test --reporter=list` |
+| Cypress | `npx cypress run --reporter spec` |
+| Mocha | `npx mocha --reporter spec --no-color` |
+| go test | `go test -v -count=1 ./...` |
+| Maven | `./mvnw test -B` |
+| Gradle | `./gradlew test` |
+| k6 | `k6 run --summary-trend-stats="avg,p(95),p(99)" <script>` |
+| Locust | `locust --headless -u 1 -r 1 --run-time 30s` |
+
+If `package.json` has specific named scripts (e.g., `test:unit`, `test:e2e`), prefer those over generic runner commands as they may include project-specific configuration.
+
+### 5. Collect and Parse Results
+
+For each test run, extract:
+
+- Total tests: passed / failed / skipped / errored
+- Duration in seconds
+- Coverage percentage (line, branch, function) if available
+- List of failed tests with:
+  - Test file path
+  - Test name / describe block
+  - Error message (first 10 lines)
+  - Stack trace hint (file:line of assertion failure)
+
+Aggregate results:
+
+- Per service: total pass/fail/skip across all test types
+- Per test type: total pass/fail/skip across all services
+- Overall: grand totals
+
+### 6. Generate Report
+
+Write the report to stdout using `references/test-report-template.md` as the structure.
+
+Include:
+
+- Executive summary with overall pass/fail status
+- Per-service breakdown
+- Failure details with actionable context
+- Environment issues encountered
+- Recommendations for improving test coverage
+
+## Parallel Execution Strategy
+
+When multiple services are affected:
+
+- Spawn one Task subagent per service for independent test execution
+- Each subagent runs all discovered test types for its assigned service
+- Main process collects results and assembles the final report
+- If only one service is affected, run sequentially without subagents
+
+## Error Handling
+
+| Situation | Behavior |
+|---|---|
+| No git repository | Error: report and exit |
+| No changed files detected | Info: suggest `--all` flag or explicit paths |
+| No tests found in service | Warning: report service as "no tests configured" |
+| Test runner not installed | `needs-setup`: suggest install command |
+| Test timeout exceeded | Kill process, report as timeout failure |
+| Environment variable missing | `needs-setup`: list required vars |
+| Docker not running | `blocked` for integration/e2e that need it |
+
+## Output Contract
+
+Always produce a report using `references/test-report-template.md` structure containing:
+
+- Changed services detection summary
+- Environment readiness matrix
+- Test results matrix (service x test-type)
+- Failure details with file paths and error messages
+- Coverage summary per service (when available)
+- Actionable recommendations
+
+## Prompt Template
+
+Invoke the skill with optional arguments:
+
+```text
+/test-all $ARGUMENTS
+```
+
+Where `$ARGUMENTS` can be:
+
+- Empty: auto-detect changed services from git, use `main` as base branch
+- `--all`: run tests for all services
+- `--base-branch=develop`: use `develop` as comparison branch
+- `services/api services/web`: explicit service paths
+- Combinations: `services/api --base-branch=develop`
+
+Default user prompt after parsing arguments:
+
+```text
+Run all applicable tests for modified services in this monorepo.
+Detect which services changed, discover test types, validate the environment, execute tests, and produce a structured report.
+```

--- a/.claude/skills/test-all/SKILL.md
+++ b/.claude/skills/test-all/SKILL.md
@@ -139,26 +139,62 @@ If a service is `needs-setup`, ask the user whether to run setup commands before
 
 ### 4. Run Tests
 
-Execute ALL test types discovered in Step 2. Run them in this order (fastest first), but never skip any type:
+#### 4a. Build Execution Queue
 
-1. **Unit tests** - timeout 5 minutes per service
-2. **Integration tests** - timeout 10 minutes per service
-3. **Component tests** - timeout 10 minutes per service
-4. **E2E tests** - timeout 15 minutes per service
-5. **Performance tests** - timeout 10 minutes per service
+From the Step 2 discovery matrix, build an execution queue listing every service + test-type combination. Output it to the user before running anything:
 
-Execution rules:
+```
+EXECUTION QUEUE (N entries):
+[ ] unit       - Jest (services/api), pytest (services/worker)
+[ ] integration - pytest (services/worker)
+[ ] e2e        - Playwright (services/web)
+[ ] performance - k6 (services/api)
+```
 
-- CRITICAL: run every test type from the Step 2 discovery matrix. Do not stop after unit or integration tests -- always continue through component, e2e, and performance tests
-- For independent services, use Task tool to launch parallel subagents (one per service)
+This queue is a binding contract. Every entry MUST be executed before generating the report.
+
+Execution order by type (fastest first):
+
+| Type | Timeout per service |
+|---|---|
+| unit | 5 minutes |
+| integration | 10 minutes |
+| component | 10 minutes |
+| e2e | 15 minutes |
+| performance | 10 minutes |
+
+#### 4b. Execute Queue (checkpoint loop)
+
+Process entries one by one. After completing each entry:
+
+1. Run the test command for this entry
+2. Record exit code, stdout/stderr, duration, coverage
+3. Mark entry as done with result (PASSED / FAILED / ERROR / TIMEOUT)
+4. Output checkpoint showing remaining queue:
+
+```
+CHECKPOINT: 2/4 complete, 2 remaining:
+[x] unit        - PASSED (42 passed, 0 failed)
+[x] integration - FAILED (8 passed, 3 failed)
+[ ] e2e         - pending
+[ ] performance - pending
+>>> Continuing with: e2e
+```
+
+5. Continue to next entry. NEVER stop the loop early.
+
+**CRITICAL**: do NOT generate the final report (Step 6) until ALL queue entries show `[x]`. If a test type fails, mark it as FAILED and move to the next entry. The loop ends only when every entry has been processed.
+
+#### 4c. Execution Rules
+
+- For independent services, use Task tool to launch parallel subagents (one per service). Each subagent follows the same queue/checkpoint pattern for its service.
 - Within a service, run test types sequentially in the order above
 - Capture full stdout/stderr for each test run
-- Record exit code, duration, and any coverage output
 - If a test suite fails, continue with remaining suites in that service and other services
 - Pass `--no-color` or equivalent flag when available for clean output parsing
 - Use `--coverage` or equivalent when the runner supports it
 
-Common run commands by runner:
+#### 4d. Common Run Commands
 
 | Runner | Command |
 |---|---|
@@ -198,10 +234,20 @@ Aggregate results:
 - Per test type: total pass/fail/skip across all services
 - Overall: grand totals
 
-Verify completeness:
+Verify completeness before proceeding to Step 6:
 
-- Cross-reference executed test types against the Step 2 discovery matrix
-- If any discovered test type was not executed, flag it as "NOT RUN" in the report with explanation
+- Every entry from the Step 4a execution queue must have a result (PASSED / FAILED / ERROR / TIMEOUT)
+- If any entry is missing a result, go back and execute it now
+- Output the final completed queue as confirmation:
+
+```
+ALL QUEUE ENTRIES PROCESSED (4/4):
+[x] unit        - PASSED
+[x] integration - FAILED
+[x] e2e         - PASSED
+[x] performance - PASSED
+>>> Proceeding to report generation
+```
 
 ### 6. Generate Report
 

--- a/.claude/skills/test-all/SKILL.md
+++ b/.claude/skills/test-all/SKILL.md
@@ -47,6 +47,7 @@ Combine all changed file paths. Map each changed file to its parent service dire
 - `Cargo.toml` (Rust)
 - `Gemfile` (Ruby)
 - `composer.json` (PHP)
+- `*.csproj` or `*.sln` (.NET / C#)
 - `Makefile` with test targets (generic)
 
 If the repository root itself is a single-service project (manifest at root level), treat the entire repo as one service.
@@ -71,6 +72,7 @@ For each affected service, scan for test runner configurations and classify test
 | `k6/` scripts or `*.k6.js` | k6 | performance |
 | `locustfile.py` or `locust/` | Locust | performance |
 | `artillery.yml` or `.artillery/` | Artillery | performance |
+| `*.csproj` + `*Tests` project | dotnet test | unit |
 
 Additionally, check `package.json` scripts for named test commands:
 
@@ -101,8 +103,8 @@ Produce a matrix: service x test-type with runner commands.
 For each service, check prerequisites:
 
 **Node.js services:**
-- `node_modules/` exists -> if not, suggest `npm install` / `yarn install` / `pnpm install`
-- Check for lockfile to determine package manager (package-lock.json / yarn.lock / pnpm-lock.yaml)
+- `node_modules/` exists -> if not, suggest `npm install` / `yarn install` / `pnpm install` / `bun install`
+- Check for lockfile to determine package manager (package-lock.json / yarn.lock / pnpm-lock.yaml / bun.lock)
 - `.env` or `.env.test` exists if referenced in configs
 
 **Python services:**
@@ -112,11 +114,15 @@ For each service, check prerequisites:
 
 **Go services:**
 - `go.sum` exists (modules downloaded)
-- Build succeeds (`go build ./...`)
+- Source valid (`go vet ./...`)
 
 **Java/Kotlin services:**
 - Build tool wrapper exists (`mvnw`, `gradlew`)
 - Dependencies cached (`~/.m2/repository` or `.gradle/`)
+
+**.NET services:**
+- .NET SDK installed (`dotnet --version`)
+- Dependencies restored (`dotnet restore` if `obj/` missing)
 
 **Integration/E2E prerequisites:**
 - Docker running (if docker-compose.yml or Dockerfile present in test config)
@@ -157,7 +163,7 @@ Common run commands by runner:
 |---|---|
 | Jest | `npx jest --ci --coverage --no-color` |
 | Vitest | `npx vitest run --coverage --reporter=verbose` |
-| pytest | `python -m pytest -v --tb=short --no-header` |
+| pytest | `python -m pytest -v --tb=short --no-header --cov` |
 | Playwright | `npx playwright test --reporter=list` |
 | Cypress | `npx cypress run --reporter spec` |
 | Mocha | `npx mocha --reporter spec --no-color` |
@@ -166,6 +172,9 @@ Common run commands by runner:
 | Gradle | `./gradlew test` |
 | k6 | `k6 run --summary-trend-stats="avg,p(95),p(99)" <script>` |
 | Locust | `locust --headless -u 1 -r 1 --run-time 30s` |
+| dotnet test | `dotnet test --no-build --verbosity normal` |
+
+Note: `--no-header` requires pytest >= 7.0. For older versions, remove this flag from the command.
 
 If `package.json` has specific named scripts (e.g., `test:unit`, `test:e2e`), prefer those over generic runner commands as they may include project-specific configuration.
 

--- a/.claude/skills/test-all/SKILL.md
+++ b/.claude/skills/test-all/SKILL.md
@@ -139,7 +139,7 @@ If a service is `needs-setup`, ask the user whether to run setup commands before
 
 ### 4. Run Tests
 
-Execute tests in priority order (fastest first):
+Execute ALL test types discovered in Step 2. Run them in this order (fastest first), but never skip any type:
 
 1. **Unit tests** - timeout 5 minutes per service
 2. **Integration tests** - timeout 10 minutes per service
@@ -149,6 +149,7 @@ Execute tests in priority order (fastest first):
 
 Execution rules:
 
+- CRITICAL: run every test type from the Step 2 discovery matrix. Do not stop after unit or integration tests -- always continue through component, e2e, and performance tests
 - For independent services, use Task tool to launch parallel subagents (one per service)
 - Within a service, run test types sequentially in the order above
 - Capture full stdout/stderr for each test run
@@ -196,6 +197,11 @@ Aggregate results:
 - Per service: total pass/fail/skip across all test types
 - Per test type: total pass/fail/skip across all services
 - Overall: grand totals
+
+Verify completeness:
+
+- Cross-reference executed test types against the Step 2 discovery matrix
+- If any discovered test type was not executed, flag it as "NOT RUN" in the report with explanation
 
 ### 6. Generate Report
 

--- a/.claude/skills/test-all/SKILL.md
+++ b/.claude/skills/test-all/SKILL.md
@@ -98,6 +98,29 @@ For Go projects, check for:
 
 Produce a matrix: service x test-type with runner commands.
 
+#### 2b. Discover Project-Specific Test Scripts
+
+Before falling back to standard runner commands, search each service for custom test scripts that the team may have configured. These take priority over generic commands because they often include project-specific flags, environment setup, or multi-step workflows.
+
+Search locations (in priority order):
+
+1. **Makefile / Taskfile.yml / justfile** -- look for targets like `test`, `test-unit`, `test-integration`, `test-e2e`, `test-perf`, `test-all`, `check`, `ci-test`
+2. **Shell scripts** -- `scripts/test*.sh`, `bin/test*`, `run-tests.sh`, `ci/*.sh`
+3. **package.json scripts** (Node.js) -- `test`, `test:unit`, `test:integration`, `test:e2e`, `test:perf`, `test:all`
+4. **pyproject.toml / tox.ini / noxfile.py** (Python) -- `[tool.tox]` envs, nox sessions like `tests`, `integration`, `e2e`
+5. **Docker Compose test services** -- `docker-compose.test.yml`, services named `*-test*`
+6. **CI config files** -- `.github/workflows/test*.yml`, `Jenkinsfile`, `.gitlab-ci.yml` -- extract test commands from CI steps as hints for local execution
+
+For each discovered script, map it to a test type (unit / integration / e2e / performance) based on name or content.
+
+**Command resolution priority** for each test type in a service:
+
+1. Project-specific script (Makefile target, shell script, tox env, etc.)
+2. Named `package.json` script (e.g., `test:e2e`)
+3. Standard runner command from the table in Step 4d
+
+Record the chosen command source in the execution queue (e.g., `Makefile:test-e2e` vs `npx playwright test`).
+
 ### 3. Validate Environment Readiness
 
 For each service, check prerequisites:
@@ -145,10 +168,10 @@ From the Step 2 discovery matrix, build an execution queue listing every service
 
 ```
 EXECUTION QUEUE (N entries):
-[ ] unit       - Jest (services/api), pytest (services/worker)
-[ ] integration - pytest (services/worker)
-[ ] e2e        - Playwright (services/web)
-[ ] performance - k6 (services/api)
+[ ] unit        - services/api (npm test:unit via package.json), services/worker (make test-unit via Makefile)
+[ ] integration - services/worker (python -m pytest tests/integration/ --cov, standard)
+[ ] e2e         - services/web (scripts/run-e2e.sh via shell script)
+[ ] performance - services/api (k6 run ..., standard)
 ```
 
 This queue is a binding contract. Every entry MUST be executed before generating the report.
@@ -213,7 +236,7 @@ CHECKPOINT: 2/4 complete, 2 remaining:
 
 Note: `--no-header` requires pytest >= 7.0. For older versions, remove this flag from the command.
 
-If `package.json` has specific named scripts (e.g., `test:unit`, `test:e2e`), prefer those over generic runner commands as they may include project-specific configuration.
+Use the command resolution priority from Step 2b: project-specific scripts first, then named package.json scripts, then standard runner commands from the table above.
 
 ### 5. Collect and Parse Results
 

--- a/.claude/skills/test-all/references/test-report-template.md
+++ b/.claude/skills/test-all/references/test-report-template.md
@@ -1,0 +1,103 @@
+# Test Run Report
+
+Use this structure for the final output.
+
+## 1. Summary
+
+| Metric | Value |
+|---|---|
+| Services tested | N |
+| Test suites run | N |
+| Total tests | N |
+| Passed | N |
+| Failed | N |
+| Skipped | N |
+| Total duration | Nm Ns |
+| Overall status | PASS / FAIL |
+
+## 2. Changed Services
+
+| Service | Path | Changed Files | Detection Method |
+|---|---|---|---|
+| api-service | `services/api/` | 12 | git diff vs main |
+| web-app | `services/web/` | 5 | git diff vs main |
+
+Detection method values:
+- `git diff vs <branch>`
+- `explicit path`
+- `--all flag`
+
+## 3. Environment Readiness
+
+| Service | Status | Issues | Fix Commands |
+|---|---|---|---|
+| api-service | ready | - | - |
+| web-app | needs-setup | node_modules missing | `cd services/web && npm install` |
+
+Status values:
+- `ready` - all prerequisites met
+- `needs-setup` - fixable issues with listed commands
+- `blocked` - critical dependency missing
+
+## 4. Test Results Matrix
+
+| Service | Unit | Integration | Component | E2E | Performance |
+|---|---|---|---|---|---|
+| api-service | 45/45 pass | 12/14 pass | - | - | - |
+| web-app | 89/90 pass | - | 15/15 pass | 8/8 pass | - |
+
+Cell format: `passed/total status` or `-` if test type not present.
+
+## 5. Failure Details
+
+### Service: `<service-name>`
+
+#### Test Type: `<type>`
+
+**Runner:** `<runner-name>` | **Command:** `<command-used>`
+
+| # | Test | File | Error |
+|---|---|---|---|
+| 1 | should validate email format | `src/validators/__tests__/email.test.ts:42` | Expected "valid" but received "invalid" |
+| 2 | should handle timeout | `src/api/__tests__/client.test.ts:88` | Timeout of 5000ms exceeded |
+
+<details>
+<summary>Full error output for test #N</summary>
+
+```
+Paste relevant error output here (first 20 lines).
+```
+
+</details>
+
+Repeat for each failing test type and service.
+
+## 6. Coverage Summary
+
+| Service | Lines | Branches | Functions | Statements |
+|---|---|---|---|---|
+| api-service | 78.5% | 65.2% | 82.1% | 79.0% |
+| web-app | 91.2% | 87.4% | 93.5% | 90.8% |
+
+Note: coverage data is only available when the test runner supports it and `--coverage` flag was used.
+If coverage is not available for a service, note "N/A" and explain why.
+
+## 7. Recommendations
+
+List actionable items based on the test run results:
+
+- **Missing test types**: services without integration/e2e tests
+- **Low coverage areas**: files or modules below threshold
+- **Flaky tests**: tests that show intermittent behavior (if detected)
+- **Environment improvements**: CI configuration suggestions
+- **New test suggestions**: uncovered code paths in changed files
+
+Format each recommendation as:
+
+| Priority | Service | Recommendation | Rationale |
+|---|---|---|---|
+| high | api-service | Add integration tests for new endpoint | Endpoint `/api/v2/users` has no integration coverage |
+| medium | web-app | Fix flaky timeout test | `client.test.ts:88` failed with timeout |
+| low | web-app | Increase branch coverage | Branch coverage 65.2% is below 80% threshold |
+
+Priority values: `critical`, `high`, `medium`, `low`.

--- a/.codex/skills/test-all/SKILL.md
+++ b/.codex/skills/test-all/SKILL.md
@@ -46,6 +46,7 @@ Combine all changed file paths. Map each changed file to its parent service dire
 - `Cargo.toml` (Rust)
 - `Gemfile` (Ruby)
 - `composer.json` (PHP)
+- `*.csproj` or `*.sln` (.NET / C#)
 - `Makefile` with test targets (generic)
 
 If the repository root itself is a single-service project (manifest at root level), treat the entire repo as one service.
@@ -70,6 +71,7 @@ For each affected service, scan for test runner configurations and classify test
 | `k6/` scripts or `*.k6.js` | k6 | performance |
 | `locustfile.py` or `locust/` | Locust | performance |
 | `artillery.yml` or `.artillery/` | Artillery | performance |
+| `*.csproj` + `*Tests` project | dotnet test | unit |
 
 Additionally, check `package.json` scripts for named test commands:
 
@@ -100,8 +102,8 @@ Produce a matrix: service x test-type with runner commands.
 For each service, check prerequisites:
 
 **Node.js services:**
-- `node_modules/` exists -> if not, suggest `npm install` / `yarn install` / `pnpm install`
-- Check for lockfile to determine package manager (package-lock.json / yarn.lock / pnpm-lock.yaml)
+- `node_modules/` exists -> if not, suggest `npm install` / `yarn install` / `pnpm install` / `bun install`
+- Check for lockfile to determine package manager (package-lock.json / yarn.lock / pnpm-lock.yaml / bun.lock)
 - `.env` or `.env.test` exists if referenced in configs
 
 **Python services:**
@@ -111,11 +113,15 @@ For each service, check prerequisites:
 
 **Go services:**
 - `go.sum` exists (modules downloaded)
-- Build succeeds (`go build ./...`)
+- Source valid (`go vet ./...`)
 
 **Java/Kotlin services:**
 - Build tool wrapper exists (`mvnw`, `gradlew`)
 - Dependencies cached (`~/.m2/repository` or `.gradle/`)
+
+**.NET services:**
+- .NET SDK installed (`dotnet --version`)
+- Dependencies restored (`dotnet restore` if `obj/` missing)
 
 **Integration/E2E prerequisites:**
 - Docker running (if docker-compose.yml or Dockerfile present in test config)
@@ -156,7 +162,7 @@ Common run commands by runner:
 |---|---|
 | Jest | `npx jest --ci --coverage --no-color` |
 | Vitest | `npx vitest run --coverage --reporter=verbose` |
-| pytest | `python -m pytest -v --tb=short --no-header` |
+| pytest | `python -m pytest -v --tb=short --no-header --cov` |
 | Playwright | `npx playwright test --reporter=list` |
 | Cypress | `npx cypress run --reporter spec` |
 | Mocha | `npx mocha --reporter spec --no-color` |
@@ -165,6 +171,9 @@ Common run commands by runner:
 | Gradle | `./gradlew test` |
 | k6 | `k6 run --summary-trend-stats="avg,p(95),p(99)" <script>` |
 | Locust | `locust --headless -u 1 -r 1 --run-time 30s` |
+| dotnet test | `dotnet test --no-build --verbosity normal` |
+
+Note: `--no-header` requires pytest >= 7.0. For older versions, remove this flag from the command.
 
 If `package.json` has specific named scripts (e.g., `test:unit`, `test:e2e`), prefer those over generic runner commands as they may include project-specific configuration.
 

--- a/.codex/skills/test-all/SKILL.md
+++ b/.codex/skills/test-all/SKILL.md
@@ -138,26 +138,62 @@ If a service is `needs-setup`, ask the user whether to run setup commands before
 
 ### 4. Run Tests
 
-Execute ALL test types discovered in Step 2. Run them in this order (fastest first), but never skip any type:
+#### 4a. Build Execution Queue
 
-1. **Unit tests** - timeout 5 minutes per service
-2. **Integration tests** - timeout 10 minutes per service
-3. **Component tests** - timeout 10 minutes per service
-4. **E2E tests** - timeout 15 minutes per service
-5. **Performance tests** - timeout 10 minutes per service
+From the Step 2 discovery matrix, build an execution queue listing every service + test-type combination. Output it to the user before running anything:
 
-Execution rules:
+```
+EXECUTION QUEUE (N entries):
+[ ] unit       - Jest (services/api), pytest (services/worker)
+[ ] integration - pytest (services/worker)
+[ ] e2e        - Playwright (services/web)
+[ ] performance - k6 (services/api)
+```
 
-- CRITICAL: run every test type from the Step 2 discovery matrix. Do not stop after unit or integration tests -- always continue through component, e2e, and performance tests
-- For independent services, use parallel execution (e.g., `codex exec` with background jobs)
+This queue is a binding contract. Every entry MUST be executed before generating the report.
+
+Execution order by type (fastest first):
+
+| Type | Timeout per service |
+|---|---|
+| unit | 5 minutes |
+| integration | 10 minutes |
+| component | 10 minutes |
+| e2e | 15 minutes |
+| performance | 10 minutes |
+
+#### 4b. Execute Queue (checkpoint loop)
+
+Process entries one by one. After completing each entry:
+
+1. Run the test command for this entry
+2. Record exit code, stdout/stderr, duration, coverage
+3. Mark entry as done with result (PASSED / FAILED / ERROR / TIMEOUT)
+4. Output checkpoint showing remaining queue:
+
+```
+CHECKPOINT: 2/4 complete, 2 remaining:
+[x] unit        - PASSED (42 passed, 0 failed)
+[x] integration - FAILED (8 passed, 3 failed)
+[ ] e2e         - pending
+[ ] performance - pending
+>>> Continuing with: e2e
+```
+
+5. Continue to next entry. NEVER stop the loop early.
+
+**CRITICAL**: do NOT generate the final report (Step 6) until ALL queue entries show `[x]`. If a test type fails, mark it as FAILED and move to the next entry. The loop ends only when every entry has been processed.
+
+#### 4c. Execution Rules
+
+- For independent services, use parallel execution (e.g., `codex exec` with background jobs). Each track follows the same queue/checkpoint pattern for its service.
 - Within a service, run test types sequentially in the order above
 - Capture full stdout/stderr for each test run
-- Record exit code, duration, and any coverage output
 - If a test suite fails, continue with remaining suites in that service and other services
 - Pass `--no-color` or equivalent flag when available for clean output parsing
 - Use `--coverage` or equivalent when the runner supports it
 
-Common run commands by runner:
+#### 4d. Common Run Commands
 
 | Runner | Command |
 |---|---|
@@ -197,10 +233,20 @@ Aggregate results:
 - Per test type: total pass/fail/skip across all services
 - Overall: grand totals
 
-Verify completeness:
+Verify completeness before proceeding to Step 6:
 
-- Cross-reference executed test types against the Step 2 discovery matrix
-- If any discovered test type was not executed, flag it as "NOT RUN" in the report with explanation
+- Every entry from the Step 4a execution queue must have a result (PASSED / FAILED / ERROR / TIMEOUT)
+- If any entry is missing a result, go back and execute it now
+- Output the final completed queue as confirmation:
+
+```
+ALL QUEUE ENTRIES PROCESSED (4/4):
+[x] unit        - PASSED
+[x] integration - FAILED
+[x] e2e         - PASSED
+[x] performance - PASSED
+>>> Proceeding to report generation
+```
 
 ### 6. Generate Report
 

--- a/.codex/skills/test-all/SKILL.md
+++ b/.codex/skills/test-all/SKILL.md
@@ -97,6 +97,29 @@ For Go projects, check for:
 
 Produce a matrix: service x test-type with runner commands.
 
+#### 2b. Discover Project-Specific Test Scripts
+
+Before falling back to standard runner commands, search each service for custom test scripts that the team may have configured. These take priority over generic commands because they often include project-specific flags, environment setup, or multi-step workflows.
+
+Search locations (in priority order):
+
+1. **Makefile / Taskfile.yml / justfile** -- look for targets like `test`, `test-unit`, `test-integration`, `test-e2e`, `test-perf`, `test-all`, `check`, `ci-test`
+2. **Shell scripts** -- `scripts/test*.sh`, `bin/test*`, `run-tests.sh`, `ci/*.sh`
+3. **package.json scripts** (Node.js) -- `test`, `test:unit`, `test:integration`, `test:e2e`, `test:perf`, `test:all`
+4. **pyproject.toml / tox.ini / noxfile.py** (Python) -- `[tool.tox]` envs, nox sessions like `tests`, `integration`, `e2e`
+5. **Docker Compose test services** -- `docker-compose.test.yml`, services named `*-test*`
+6. **CI config files** -- `.github/workflows/test*.yml`, `Jenkinsfile`, `.gitlab-ci.yml` -- extract test commands from CI steps as hints for local execution
+
+For each discovered script, map it to a test type (unit / integration / e2e / performance) based on name or content.
+
+**Command resolution priority** for each test type in a service:
+
+1. Project-specific script (Makefile target, shell script, tox env, etc.)
+2. Named `package.json` script (e.g., `test:e2e`)
+3. Standard runner command from the table in Step 4d
+
+Record the chosen command source in the execution queue (e.g., `Makefile:test-e2e` vs `npx playwright test`).
+
 ### 3. Validate Environment Readiness
 
 For each service, check prerequisites:
@@ -144,10 +167,10 @@ From the Step 2 discovery matrix, build an execution queue listing every service
 
 ```
 EXECUTION QUEUE (N entries):
-[ ] unit       - Jest (services/api), pytest (services/worker)
-[ ] integration - pytest (services/worker)
-[ ] e2e        - Playwright (services/web)
-[ ] performance - k6 (services/api)
+[ ] unit        - services/api (npm test:unit via package.json), services/worker (make test-unit via Makefile)
+[ ] integration - services/worker (python -m pytest tests/integration/ --cov, standard)
+[ ] e2e         - services/web (scripts/run-e2e.sh via shell script)
+[ ] performance - services/api (k6 run ..., standard)
 ```
 
 This queue is a binding contract. Every entry MUST be executed before generating the report.
@@ -212,7 +235,7 @@ CHECKPOINT: 2/4 complete, 2 remaining:
 
 Note: `--no-header` requires pytest >= 7.0. For older versions, remove this flag from the command.
 
-If `package.json` has specific named scripts (e.g., `test:unit`, `test:e2e`), prefer those over generic runner commands as they may include project-specific configuration.
+Use the command resolution priority from Step 2b: project-specific scripts first, then named package.json scripts, then standard runner commands from the table above.
 
 ### 5. Collect and Parse Results
 

--- a/.codex/skills/test-all/SKILL.md
+++ b/.codex/skills/test-all/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: test-all
+description: Detect modified services in a monorepo, discover all test types (unit, integration, component, e2e, performance), validate environment readiness, run tests, and produce a structured report. Use when you need to run all applicable tests after code changes.
+argument-hint: "[service-path or --all] [--base-branch=main]"
+---
+
+# Test All
+
+## Goal
+
+Automatically detect changed services, discover all available test suites, validate environment readiness, execute tests, and produce a structured report.
+
+## Required Inputs
+
+Collect before execution:
+
+- Repository root path (default: current working directory)
+- Base branch for diff comparison (default: `main`, override with `--base-branch=<branch>`)
+- Scope: auto-detect from git changes, explicit service paths, or `--all` for full run
+
+If `$ARGUMENTS` contains paths, use those as explicit service targets.
+If `$ARGUMENTS` contains `--all`, scan every service in the monorepo.
+Otherwise, auto-detect affected services from git changes.
+
+## Workflow
+
+### 1. Detect Changed Services
+
+Identify which services have been modified:
+
+```bash
+# All changes in current branch vs base
+git diff --name-only <base-branch>...HEAD 2>/dev/null || true
+# Unstaged changes
+git diff --name-only
+# Staged changes
+git diff --name-only --cached
+```
+
+Combine all changed file paths. Map each changed file to its parent service directory. A service directory is identified by the presence of a project manifest at its root:
+
+- `package.json` (Node.js / frontend)
+- `pyproject.toml` or `setup.py` or `setup.cfg` (Python)
+- `go.mod` (Go)
+- `pom.xml` or `build.gradle` or `build.gradle.kts` (Java/Kotlin)
+- `Cargo.toml` (Rust)
+- `Gemfile` (Ruby)
+- `composer.json` (PHP)
+- `Makefile` with test targets (generic)
+
+If the repository root itself is a single-service project (manifest at root level), treat the entire repo as one service.
+
+Report the list of affected services with the count of changed files per service.
+
+### 2. Discover Test Configurations
+
+For each affected service, scan for test runner configurations and classify test types:
+
+| Marker | Runner | Default Type |
+|---|---|---|
+| `jest.config.*` or `jest` key in package.json | Jest | unit |
+| `vitest.config.*` | Vitest | unit |
+| `pytest.ini` / `pyproject.toml` with `[tool.pytest]` / `conftest.py` | pytest | unit |
+| `playwright.config.*` | Playwright | e2e |
+| `cypress.config.*` or `cypress/` directory | Cypress | e2e |
+| `.mocharc.*` or `mocha` key in package.json | Mocha | unit |
+| `*_test.go` files | go test | unit |
+| `src/test/` + `pom.xml` | Maven (JUnit) | unit |
+| `src/test/` + `build.gradle*` | Gradle (JUnit) | unit |
+| `k6/` scripts or `*.k6.js` | k6 | performance |
+| `locustfile.py` or `locust/` | Locust | performance |
+| `artillery.yml` or `.artillery/` | Artillery | performance |
+
+Additionally, check `package.json` scripts for named test commands:
+
+- `test` or `test:unit` -> unit
+- `test:integration` or `test:int` -> integration
+- `test:component` -> component
+- `test:e2e` or `test:playwright` or `test:cypress` -> e2e
+- `test:perf` or `test:performance` or `test:load` -> performance
+- `test:all` -> all types
+
+For Python projects, check for directory conventions:
+
+- `tests/unit/` or `tests/test_*.py` at root -> unit
+- `tests/integration/` -> integration
+- `tests/e2e/` -> e2e
+- `tests/performance/` or `tests/load/` -> performance
+
+For Go projects, check for:
+
+- `*_test.go` in source directories -> unit
+- `tests/integration/` or `_integration_test.go` suffix -> integration
+- `tests/e2e/` -> e2e
+
+Produce a matrix: service x test-type with runner commands.
+
+### 3. Validate Environment Readiness
+
+For each service, check prerequisites:
+
+**Node.js services:**
+- `node_modules/` exists -> if not, suggest `npm install` / `yarn install` / `pnpm install`
+- Check for lockfile to determine package manager (package-lock.json / yarn.lock / pnpm-lock.yaml)
+- `.env` or `.env.test` exists if referenced in configs
+
+**Python services:**
+- Virtual environment exists (`.venv/`, `venv/`, or active conda env)
+- Dependencies installed (check for `requirements.txt`, `pyproject.toml` with deps)
+- Test dependencies present (pytest in installed packages)
+
+**Go services:**
+- `go.sum` exists (modules downloaded)
+- Build succeeds (`go build ./...`)
+
+**Java/Kotlin services:**
+- Build tool wrapper exists (`mvnw`, `gradlew`)
+- Dependencies cached (`~/.m2/repository` or `.gradle/`)
+
+**Integration/E2E prerequisites:**
+- Docker running (if docker-compose.yml or Dockerfile present in test config)
+- Test database available (check env vars like DATABASE_URL, TEST_DATABASE_URL)
+- Required services running (check ports or health endpoints if configured)
+
+Classify each service:
+
+- `ready` - all prerequisites met, tests can run immediately
+- `needs-setup` - missing prerequisites with specific fix commands
+- `blocked` - critical dependency missing that cannot be auto-resolved
+
+If a service is `needs-setup`, ask the user whether to run setup commands before continuing.
+
+### 4. Run Tests
+
+Execute tests in priority order (fastest first):
+
+1. **Unit tests** - timeout 5 minutes per service
+2. **Integration tests** - timeout 10 minutes per service
+3. **Component tests** - timeout 10 minutes per service
+4. **E2E tests** - timeout 15 minutes per service
+5. **Performance tests** - timeout 10 minutes per service
+
+Execution rules:
+
+- For independent services, use parallel execution (e.g., `codex exec` with background jobs)
+- Within a service, run test types sequentially in the order above
+- Capture full stdout/stderr for each test run
+- Record exit code, duration, and any coverage output
+- If a test suite fails, continue with remaining suites in that service and other services
+- Pass `--no-color` or equivalent flag when available for clean output parsing
+- Use `--coverage` or equivalent when the runner supports it
+
+Common run commands by runner:
+
+| Runner | Command |
+|---|---|
+| Jest | `npx jest --ci --coverage --no-color` |
+| Vitest | `npx vitest run --coverage --reporter=verbose` |
+| pytest | `python -m pytest -v --tb=short --no-header` |
+| Playwright | `npx playwright test --reporter=list` |
+| Cypress | `npx cypress run --reporter spec` |
+| Mocha | `npx mocha --reporter spec --no-color` |
+| go test | `go test -v -count=1 ./...` |
+| Maven | `./mvnw test -B` |
+| Gradle | `./gradlew test` |
+| k6 | `k6 run --summary-trend-stats="avg,p(95),p(99)" <script>` |
+| Locust | `locust --headless -u 1 -r 1 --run-time 30s` |
+
+If `package.json` has specific named scripts (e.g., `test:unit`, `test:e2e`), prefer those over generic runner commands as they may include project-specific configuration.
+
+### 5. Collect and Parse Results
+
+For each test run, extract:
+
+- Total tests: passed / failed / skipped / errored
+- Duration in seconds
+- Coverage percentage (line, branch, function) if available
+- List of failed tests with:
+  - Test file path
+  - Test name / describe block
+  - Error message (first 10 lines)
+  - Stack trace hint (file:line of assertion failure)
+
+Aggregate results:
+
+- Per service: total pass/fail/skip across all test types
+- Per test type: total pass/fail/skip across all services
+- Overall: grand totals
+
+### 6. Generate Report
+
+Write the report to stdout using `references/test-report-template.md` as the structure.
+
+Include:
+
+- Executive summary with overall pass/fail status
+- Per-service breakdown
+- Failure details with actionable context
+- Environment issues encountered
+- Recommendations for improving test coverage
+
+## Parallel Execution Strategy
+
+When multiple services are affected:
+
+- Launch one parallel track per service for independent test execution
+- Each track runs all discovered test types for its assigned service
+- Main process collects results and assembles the final report
+- If only one service is affected, run sequentially
+
+## Error Handling
+
+| Situation | Behavior |
+|---|---|
+| No git repository | Error: report and exit |
+| No changed files detected | Info: suggest `--all` flag or explicit paths |
+| No tests found in service | Warning: report service as "no tests configured" |
+| Test runner not installed | `needs-setup`: suggest install command |
+| Test timeout exceeded | Kill process, report as timeout failure |
+| Environment variable missing | `needs-setup`: list required vars |
+| Docker not running | `blocked` for integration/e2e that need it |
+
+## Output Contract
+
+Always produce a report using `references/test-report-template.md` structure containing:
+
+- Changed services detection summary
+- Environment readiness matrix
+- Test results matrix (service x test-type)
+- Failure details with file paths and error messages
+- Coverage summary per service (when available)
+- Actionable recommendations
+
+## Prompt Template
+
+Invoke the skill with optional arguments:
+
+```text
+/test-all $ARGUMENTS
+```
+
+Where `$ARGUMENTS` can be:
+
+- Empty: auto-detect changed services from git, use `main` as base branch
+- `--all`: run tests for all services
+- `--base-branch=develop`: use `develop` as comparison branch
+- `services/api services/web`: explicit service paths
+- Combinations: `services/api --base-branch=develop`
+
+Default user prompt after parsing arguments:
+
+```text
+Run all applicable tests for modified services in this monorepo.
+Detect which services changed, discover test types, validate the environment, execute tests, and produce a structured report.
+```

--- a/.codex/skills/test-all/SKILL.md
+++ b/.codex/skills/test-all/SKILL.md
@@ -138,7 +138,7 @@ If a service is `needs-setup`, ask the user whether to run setup commands before
 
 ### 4. Run Tests
 
-Execute tests in priority order (fastest first):
+Execute ALL test types discovered in Step 2. Run them in this order (fastest first), but never skip any type:
 
 1. **Unit tests** - timeout 5 minutes per service
 2. **Integration tests** - timeout 10 minutes per service
@@ -148,6 +148,7 @@ Execute tests in priority order (fastest first):
 
 Execution rules:
 
+- CRITICAL: run every test type from the Step 2 discovery matrix. Do not stop after unit or integration tests -- always continue through component, e2e, and performance tests
 - For independent services, use parallel execution (e.g., `codex exec` with background jobs)
 - Within a service, run test types sequentially in the order above
 - Capture full stdout/stderr for each test run
@@ -195,6 +196,11 @@ Aggregate results:
 - Per service: total pass/fail/skip across all test types
 - Per test type: total pass/fail/skip across all services
 - Overall: grand totals
+
+Verify completeness:
+
+- Cross-reference executed test types against the Step 2 discovery matrix
+- If any discovered test type was not executed, flag it as "NOT RUN" in the report with explanation
 
 ### 6. Generate Report
 

--- a/.codex/skills/test-all/SKILL.md
+++ b/.codex/skills/test-all/SKILL.md
@@ -35,9 +35,11 @@ git diff --name-only <base-branch>...HEAD 2>/dev/null || true
 git diff --name-only
 # Staged changes
 git diff --name-only --cached
+# Untracked files (new files not yet staged)
+git ls-files --others --exclude-standard
 ```
 
-Combine all changed file paths. Map each changed file to its parent service directory. A service directory is identified by the presence of a project manifest at its root:
+Combine all changed file paths (including untracked). Map each changed file to its parent service directory. A service directory is identified by the presence of a project manifest at its root:
 
 - `package.json` (Node.js / frontend)
 - `pyproject.toml` or `setup.py` or `setup.cfg` (Python)
@@ -61,7 +63,7 @@ For each affected service, scan for test runner configurations and classify test
 |---|---|---|
 | `jest.config.*` or `jest` key in package.json | Jest | unit |
 | `vitest.config.*` | Vitest | unit |
-| `pytest.ini` / `pyproject.toml` with `[tool.pytest]` / `conftest.py` | pytest | unit |
+| `pytest.ini` / `pyproject.toml` with `[tool.pytest.ini_options]` / `conftest.py` | pytest | unit |
 | `playwright.config.*` | Playwright | e2e |
 | `cypress.config.*` or `cypress/` directory | Cypress | e2e |
 | `.mocharc.*` or `mocha` key in package.json | Mocha | unit |
@@ -222,7 +224,7 @@ CHECKPOINT: 2/4 complete, 2 remaining:
 |---|---|
 | Jest | `npx jest --ci --coverage --no-color` |
 | Vitest | `npx vitest run --coverage --reporter=verbose` |
-| pytest | `python -m pytest -v --tb=short --no-header --cov` |
+| pytest | `python -m pytest -v --tb=short --no-header` (add `--cov` only if pytest-cov is installed) |
 | Playwright | `npx playwright test --reporter=list` |
 | Cypress | `npx cypress run --reporter spec` |
 | Mocha | `npx mocha --reporter spec --no-color` |
@@ -233,7 +235,7 @@ CHECKPOINT: 2/4 complete, 2 remaining:
 | Locust | `locust --headless -u 1 -r 1 --run-time 30s` |
 | dotnet test | `dotnet test --no-build --verbosity normal` |
 
-Note: `--no-header` requires pytest >= 7.0. For older versions, remove this flag from the command.
+Note: `--no-header` requires pytest >= 7.0. For older versions, remove this flag. To check if pytest-cov is available, run `python -m pytest --co -q --cov 2>&1 | head -1` -- if it errors with "unrecognized arguments", omit `--cov`.
 
 Use the command resolution priority from Step 2b: project-specific scripts first, then named package.json scripts, then standard runner commands from the table above.
 

--- a/.codex/skills/test-all/agents/openai.yaml
+++ b/.codex/skills/test-all/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Monorepo Test Runner"
+  short_description: "Detect changes, discover tests, run all suites"
+  default_prompt: "Use $test-all to detect modified services, discover all test types (unit, integration, component, e2e, performance), validate environment readiness, run tests, and produce a structured report."

--- a/.codex/skills/test-all/references/test-report-template.md
+++ b/.codex/skills/test-all/references/test-report-template.md
@@ -1,0 +1,103 @@
+# Test Run Report
+
+Use this structure for the final output.
+
+## 1. Summary
+
+| Metric | Value |
+|---|---|
+| Services tested | N |
+| Test suites run | N |
+| Total tests | N |
+| Passed | N |
+| Failed | N |
+| Skipped | N |
+| Total duration | Nm Ns |
+| Overall status | PASS / FAIL |
+
+## 2. Changed Services
+
+| Service | Path | Changed Files | Detection Method |
+|---|---|---|---|
+| api-service | `services/api/` | 12 | git diff vs main |
+| web-app | `services/web/` | 5 | git diff vs main |
+
+Detection method values:
+- `git diff vs <branch>`
+- `explicit path`
+- `--all flag`
+
+## 3. Environment Readiness
+
+| Service | Status | Issues | Fix Commands |
+|---|---|---|---|
+| api-service | ready | - | - |
+| web-app | needs-setup | node_modules missing | `cd services/web && npm install` |
+
+Status values:
+- `ready` - all prerequisites met
+- `needs-setup` - fixable issues with listed commands
+- `blocked` - critical dependency missing
+
+## 4. Test Results Matrix
+
+| Service | Unit | Integration | Component | E2E | Performance |
+|---|---|---|---|---|---|
+| api-service | 45/45 pass | 12/14 pass | - | - | - |
+| web-app | 89/90 pass | - | 15/15 pass | 8/8 pass | - |
+
+Cell format: `passed/total status` or `-` if test type not present.
+
+## 5. Failure Details
+
+### Service: `<service-name>`
+
+#### Test Type: `<type>`
+
+**Runner:** `<runner-name>` | **Command:** `<command-used>`
+
+| # | Test | File | Error |
+|---|---|---|---|
+| 1 | should validate email format | `src/validators/__tests__/email.test.ts:42` | Expected "valid" but received "invalid" |
+| 2 | should handle timeout | `src/api/__tests__/client.test.ts:88` | Timeout of 5000ms exceeded |
+
+<details>
+<summary>Full error output for test #N</summary>
+
+```
+Paste relevant error output here (first 20 lines).
+```
+
+</details>
+
+Repeat for each failing test type and service.
+
+## 6. Coverage Summary
+
+| Service | Lines | Branches | Functions | Statements |
+|---|---|---|---|---|
+| api-service | 78.5% | 65.2% | 82.1% | 79.0% |
+| web-app | 91.2% | 87.4% | 93.5% | 90.8% |
+
+Note: coverage data is only available when the test runner supports it and `--coverage` flag was used.
+If coverage is not available for a service, note "N/A" and explain why.
+
+## 7. Recommendations
+
+List actionable items based on the test run results:
+
+- **Missing test types**: services without integration/e2e tests
+- **Low coverage areas**: files or modules below threshold
+- **Flaky tests**: tests that show intermittent behavior (if detected)
+- **Environment improvements**: CI configuration suggestions
+- **New test suggestions**: uncovered code paths in changed files
+
+Format each recommendation as:
+
+| Priority | Service | Recommendation | Rationale |
+|---|---|---|---|
+| high | api-service | Add integration tests for new endpoint | Endpoint `/api/v2/users` has no integration coverage |
+| medium | web-app | Fix flaky timeout test | `client.test.ts:88` failed with timeout |
+| low | web-app | Increase branch coverage | Branch coverage 65.2% is below 80% threshold |
+
+Priority values: `critical`, `high`, `medium`, `low`.

--- a/.factory/skills/test-all/SKILL.md
+++ b/.factory/skills/test-all/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: test-all
+description: Detect modified services in a monorepo, discover all test types (unit, integration, component, e2e, performance), validate environment readiness, run tests, and produce a structured report. Use when you need to run all applicable tests after code changes.
+argument-hint: "[service-path or --all] [--base-branch=main]"
+---
+
+# Test All
+
+## Goal
+
+Automatically detect changed services, discover all available test suites, validate environment readiness, execute tests, and produce a structured report.
+
+## Required Inputs
+
+Collect before execution:
+
+- Repository root path (default: current working directory)
+- Base branch for diff comparison (default: `main`, override with `--base-branch=<branch>`)
+- Scope: auto-detect from git changes, explicit service paths, or `--all` for full run
+
+If `$ARGUMENTS` contains paths, use those as explicit service targets.
+If `$ARGUMENTS` contains `--all`, scan every service in the monorepo.
+Otherwise, auto-detect affected services from git changes.
+
+## Workflow
+
+### 1. Detect Changed Services
+
+Identify which services have been modified:
+
+```bash
+# All changes in current branch vs base
+git diff --name-only <base-branch>...HEAD 2>/dev/null || true
+# Unstaged changes
+git diff --name-only
+# Staged changes
+git diff --name-only --cached
+```
+
+Combine all changed file paths. Map each changed file to its parent service directory. A service directory is identified by the presence of a project manifest at its root:
+
+- `package.json` (Node.js / frontend)
+- `pyproject.toml` or `setup.py` or `setup.cfg` (Python)
+- `go.mod` (Go)
+- `pom.xml` or `build.gradle` or `build.gradle.kts` (Java/Kotlin)
+- `Cargo.toml` (Rust)
+- `Gemfile` (Ruby)
+- `composer.json` (PHP)
+- `Makefile` with test targets (generic)
+
+If the repository root itself is a single-service project (manifest at root level), treat the entire repo as one service.
+
+Report the list of affected services with the count of changed files per service.
+
+### 2. Discover Test Configurations
+
+For each affected service, scan for test runner configurations and classify test types:
+
+| Marker | Runner | Default Type |
+|---|---|---|
+| `jest.config.*` or `jest` key in package.json | Jest | unit |
+| `vitest.config.*` | Vitest | unit |
+| `pytest.ini` / `pyproject.toml` with `[tool.pytest]` / `conftest.py` | pytest | unit |
+| `playwright.config.*` | Playwright | e2e |
+| `cypress.config.*` or `cypress/` directory | Cypress | e2e |
+| `.mocharc.*` or `mocha` key in package.json | Mocha | unit |
+| `*_test.go` files | go test | unit |
+| `src/test/` + `pom.xml` | Maven (JUnit) | unit |
+| `src/test/` + `build.gradle*` | Gradle (JUnit) | unit |
+| `k6/` scripts or `*.k6.js` | k6 | performance |
+| `locustfile.py` or `locust/` | Locust | performance |
+| `artillery.yml` or `.artillery/` | Artillery | performance |
+
+Additionally, check `package.json` scripts for named test commands:
+
+- `test` or `test:unit` -> unit
+- `test:integration` or `test:int` -> integration
+- `test:component` -> component
+- `test:e2e` or `test:playwright` or `test:cypress` -> e2e
+- `test:perf` or `test:performance` or `test:load` -> performance
+- `test:all` -> all types
+
+For Python projects, check for directory conventions:
+
+- `tests/unit/` or `tests/test_*.py` at root -> unit
+- `tests/integration/` -> integration
+- `tests/e2e/` -> e2e
+- `tests/performance/` or `tests/load/` -> performance
+
+For Go projects, check for:
+
+- `*_test.go` in source directories -> unit
+- `tests/integration/` or `_integration_test.go` suffix -> integration
+- `tests/e2e/` -> e2e
+
+Produce a matrix: service x test-type with runner commands.
+
+### 3. Validate Environment Readiness
+
+For each service, check prerequisites:
+
+**Node.js services:**
+- `node_modules/` exists -> if not, suggest `npm install` / `yarn install` / `pnpm install`
+- Check for lockfile to determine package manager (package-lock.json / yarn.lock / pnpm-lock.yaml)
+- `.env` or `.env.test` exists if referenced in configs
+
+**Python services:**
+- Virtual environment exists (`.venv/`, `venv/`, or active conda env)
+- Dependencies installed (check for `requirements.txt`, `pyproject.toml` with deps)
+- Test dependencies present (pytest in installed packages)
+
+**Go services:**
+- `go.sum` exists (modules downloaded)
+- Build succeeds (`go build ./...`)
+
+**Java/Kotlin services:**
+- Build tool wrapper exists (`mvnw`, `gradlew`)
+- Dependencies cached (`~/.m2/repository` or `.gradle/`)
+
+**Integration/E2E prerequisites:**
+- Docker running (if docker-compose.yml or Dockerfile present in test config)
+- Test database available (check env vars like DATABASE_URL, TEST_DATABASE_URL)
+- Required services running (check ports or health endpoints if configured)
+
+Classify each service:
+
+- `ready` - all prerequisites met, tests can run immediately
+- `needs-setup` - missing prerequisites with specific fix commands
+- `blocked` - critical dependency missing that cannot be auto-resolved
+
+If a service is `needs-setup`, ask the user whether to run setup commands before continuing.
+
+### 4. Run Tests
+
+Execute tests in priority order (fastest first):
+
+1. **Unit tests** - timeout 5 minutes per service
+2. **Integration tests** - timeout 10 minutes per service
+3. **Component tests** - timeout 10 minutes per service
+4. **E2E tests** - timeout 15 minutes per service
+5. **Performance tests** - timeout 10 minutes per service
+
+Execution rules:
+
+- For independent services, launch parallel execution (one per service)
+- Within a service, run test types sequentially in the order above
+- Capture full stdout/stderr for each test run
+- Record exit code, duration, and any coverage output
+- If a test suite fails, continue with remaining suites in that service and other services
+- Pass `--no-color` or equivalent flag when available for clean output parsing
+- Use `--coverage` or equivalent when the runner supports it
+
+Common run commands by runner:
+
+| Runner | Command |
+|---|---|
+| Jest | `npx jest --ci --coverage --no-color` |
+| Vitest | `npx vitest run --coverage --reporter=verbose` |
+| pytest | `python -m pytest -v --tb=short --no-header` |
+| Playwright | `npx playwright test --reporter=list` |
+| Cypress | `npx cypress run --reporter spec` |
+| Mocha | `npx mocha --reporter spec --no-color` |
+| go test | `go test -v -count=1 ./...` |
+| Maven | `./mvnw test -B` |
+| Gradle | `./gradlew test` |
+| k6 | `k6 run --summary-trend-stats="avg,p(95),p(99)" <script>` |
+| Locust | `locust --headless -u 1 -r 1 --run-time 30s` |
+
+If `package.json` has specific named scripts (e.g., `test:unit`, `test:e2e`), prefer those over generic runner commands as they may include project-specific configuration.
+
+### 5. Collect and Parse Results
+
+For each test run, extract:
+
+- Total tests: passed / failed / skipped / errored
+- Duration in seconds
+- Coverage percentage (line, branch, function) if available
+- List of failed tests with:
+  - Test file path
+  - Test name / describe block
+  - Error message (first 10 lines)
+  - Stack trace hint (file:line of assertion failure)
+
+Aggregate results:
+
+- Per service: total pass/fail/skip across all test types
+- Per test type: total pass/fail/skip across all services
+- Overall: grand totals
+
+### 6. Generate Report
+
+Write the report to stdout using `references/test-report-template.md` as the structure.
+
+Include:
+
+- Executive summary with overall pass/fail status
+- Per-service breakdown
+- Failure details with actionable context
+- Environment issues encountered
+- Recommendations for improving test coverage
+
+## Parallel Execution Strategy
+
+When multiple services are affected:
+
+- Launch one parallel track per service for independent test execution
+- Each track runs all discovered test types for its assigned service
+- Main process collects results and assembles the final report
+- If only one service is affected, run sequentially
+
+## Error Handling
+
+| Situation | Behavior |
+|---|---|
+| No git repository | Error: report and exit |
+| No changed files detected | Info: suggest `--all` flag or explicit paths |
+| No tests found in service | Warning: report service as "no tests configured" |
+| Test runner not installed | `needs-setup`: suggest install command |
+| Test timeout exceeded | Kill process, report as timeout failure |
+| Environment variable missing | `needs-setup`: list required vars |
+| Docker not running | `blocked` for integration/e2e that need it |
+
+## Output Contract
+
+Always produce a report using `references/test-report-template.md` structure containing:
+
+- Changed services detection summary
+- Environment readiness matrix
+- Test results matrix (service x test-type)
+- Failure details with file paths and error messages
+- Coverage summary per service (when available)
+- Actionable recommendations
+
+## Prompt Template
+
+Invoke the skill with optional arguments:
+
+```text
+/test-all $ARGUMENTS
+```
+
+Where `$ARGUMENTS` can be:
+
+- Empty: auto-detect changed services from git, use `main` as base branch
+- `--all`: run tests for all services
+- `--base-branch=develop`: use `develop` as comparison branch
+- `services/api services/web`: explicit service paths
+- Combinations: `services/api --base-branch=develop`
+
+Default user prompt after parsing arguments:
+
+```text
+Run all applicable tests for modified services in this monorepo.
+Detect which services changed, discover test types, validate the environment, execute tests, and produce a structured report.
+```

--- a/.factory/skills/test-all/SKILL.md
+++ b/.factory/skills/test-all/SKILL.md
@@ -46,6 +46,7 @@ Combine all changed file paths. Map each changed file to its parent service dire
 - `Cargo.toml` (Rust)
 - `Gemfile` (Ruby)
 - `composer.json` (PHP)
+- `*.csproj` or `*.sln` (.NET / C#)
 - `Makefile` with test targets (generic)
 
 If the repository root itself is a single-service project (manifest at root level), treat the entire repo as one service.
@@ -70,6 +71,7 @@ For each affected service, scan for test runner configurations and classify test
 | `k6/` scripts or `*.k6.js` | k6 | performance |
 | `locustfile.py` or `locust/` | Locust | performance |
 | `artillery.yml` or `.artillery/` | Artillery | performance |
+| `*.csproj` + `*Tests` project | dotnet test | unit |
 
 Additionally, check `package.json` scripts for named test commands:
 
@@ -100,8 +102,8 @@ Produce a matrix: service x test-type with runner commands.
 For each service, check prerequisites:
 
 **Node.js services:**
-- `node_modules/` exists -> if not, suggest `npm install` / `yarn install` / `pnpm install`
-- Check for lockfile to determine package manager (package-lock.json / yarn.lock / pnpm-lock.yaml)
+- `node_modules/` exists -> if not, suggest `npm install` / `yarn install` / `pnpm install` / `bun install`
+- Check for lockfile to determine package manager (package-lock.json / yarn.lock / pnpm-lock.yaml / bun.lock)
 - `.env` or `.env.test` exists if referenced in configs
 
 **Python services:**
@@ -111,11 +113,15 @@ For each service, check prerequisites:
 
 **Go services:**
 - `go.sum` exists (modules downloaded)
-- Build succeeds (`go build ./...`)
+- Source valid (`go vet ./...`)
 
 **Java/Kotlin services:**
 - Build tool wrapper exists (`mvnw`, `gradlew`)
 - Dependencies cached (`~/.m2/repository` or `.gradle/`)
+
+**.NET services:**
+- .NET SDK installed (`dotnet --version`)
+- Dependencies restored (`dotnet restore` if `obj/` missing)
 
 **Integration/E2E prerequisites:**
 - Docker running (if docker-compose.yml or Dockerfile present in test config)
@@ -156,7 +162,7 @@ Common run commands by runner:
 |---|---|
 | Jest | `npx jest --ci --coverage --no-color` |
 | Vitest | `npx vitest run --coverage --reporter=verbose` |
-| pytest | `python -m pytest -v --tb=short --no-header` |
+| pytest | `python -m pytest -v --tb=short --no-header --cov` |
 | Playwright | `npx playwright test --reporter=list` |
 | Cypress | `npx cypress run --reporter spec` |
 | Mocha | `npx mocha --reporter spec --no-color` |
@@ -165,6 +171,9 @@ Common run commands by runner:
 | Gradle | `./gradlew test` |
 | k6 | `k6 run --summary-trend-stats="avg,p(95),p(99)" <script>` |
 | Locust | `locust --headless -u 1 -r 1 --run-time 30s` |
+| dotnet test | `dotnet test --no-build --verbosity normal` |
+
+Note: `--no-header` requires pytest >= 7.0. For older versions, remove this flag from the command.
 
 If `package.json` has specific named scripts (e.g., `test:unit`, `test:e2e`), prefer those over generic runner commands as they may include project-specific configuration.
 

--- a/.factory/skills/test-all/SKILL.md
+++ b/.factory/skills/test-all/SKILL.md
@@ -97,6 +97,29 @@ For Go projects, check for:
 
 Produce a matrix: service x test-type with runner commands.
 
+#### 2b. Discover Project-Specific Test Scripts
+
+Before falling back to standard runner commands, search each service for custom test scripts that the team may have configured. These take priority over generic commands because they often include project-specific flags, environment setup, or multi-step workflows.
+
+Search locations (in priority order):
+
+1. **Makefile / Taskfile.yml / justfile** -- look for targets like `test`, `test-unit`, `test-integration`, `test-e2e`, `test-perf`, `test-all`, `check`, `ci-test`
+2. **Shell scripts** -- `scripts/test*.sh`, `bin/test*`, `run-tests.sh`, `ci/*.sh`
+3. **package.json scripts** (Node.js) -- `test`, `test:unit`, `test:integration`, `test:e2e`, `test:perf`, `test:all`
+4. **pyproject.toml / tox.ini / noxfile.py** (Python) -- `[tool.tox]` envs, nox sessions like `tests`, `integration`, `e2e`
+5. **Docker Compose test services** -- `docker-compose.test.yml`, services named `*-test*`
+6. **CI config files** -- `.github/workflows/test*.yml`, `Jenkinsfile`, `.gitlab-ci.yml` -- extract test commands from CI steps as hints for local execution
+
+For each discovered script, map it to a test type (unit / integration / e2e / performance) based on name or content.
+
+**Command resolution priority** for each test type in a service:
+
+1. Project-specific script (Makefile target, shell script, tox env, etc.)
+2. Named `package.json` script (e.g., `test:e2e`)
+3. Standard runner command from the table in Step 4d
+
+Record the chosen command source in the execution queue (e.g., `Makefile:test-e2e` vs `npx playwright test`).
+
 ### 3. Validate Environment Readiness
 
 For each service, check prerequisites:
@@ -144,10 +167,10 @@ From the Step 2 discovery matrix, build an execution queue listing every service
 
 ```
 EXECUTION QUEUE (N entries):
-[ ] unit       - Jest (services/api), pytest (services/worker)
-[ ] integration - pytest (services/worker)
-[ ] e2e        - Playwright (services/web)
-[ ] performance - k6 (services/api)
+[ ] unit        - services/api (npm test:unit via package.json), services/worker (make test-unit via Makefile)
+[ ] integration - services/worker (python -m pytest tests/integration/ --cov, standard)
+[ ] e2e         - services/web (scripts/run-e2e.sh via shell script)
+[ ] performance - services/api (k6 run ..., standard)
 ```
 
 This queue is a binding contract. Every entry MUST be executed before generating the report.
@@ -212,7 +235,7 @@ CHECKPOINT: 2/4 complete, 2 remaining:
 
 Note: `--no-header` requires pytest >= 7.0. For older versions, remove this flag from the command.
 
-If `package.json` has specific named scripts (e.g., `test:unit`, `test:e2e`), prefer those over generic runner commands as they may include project-specific configuration.
+Use the command resolution priority from Step 2b: project-specific scripts first, then named package.json scripts, then standard runner commands from the table above.
 
 ### 5. Collect and Parse Results
 

--- a/.factory/skills/test-all/SKILL.md
+++ b/.factory/skills/test-all/SKILL.md
@@ -35,9 +35,11 @@ git diff --name-only <base-branch>...HEAD 2>/dev/null || true
 git diff --name-only
 # Staged changes
 git diff --name-only --cached
+# Untracked files (new files not yet staged)
+git ls-files --others --exclude-standard
 ```
 
-Combine all changed file paths. Map each changed file to its parent service directory. A service directory is identified by the presence of a project manifest at its root:
+Combine all changed file paths (including untracked). Map each changed file to its parent service directory. A service directory is identified by the presence of a project manifest at its root:
 
 - `package.json` (Node.js / frontend)
 - `pyproject.toml` or `setup.py` or `setup.cfg` (Python)
@@ -61,7 +63,7 @@ For each affected service, scan for test runner configurations and classify test
 |---|---|---|
 | `jest.config.*` or `jest` key in package.json | Jest | unit |
 | `vitest.config.*` | Vitest | unit |
-| `pytest.ini` / `pyproject.toml` with `[tool.pytest]` / `conftest.py` | pytest | unit |
+| `pytest.ini` / `pyproject.toml` with `[tool.pytest.ini_options]` / `conftest.py` | pytest | unit |
 | `playwright.config.*` | Playwright | e2e |
 | `cypress.config.*` or `cypress/` directory | Cypress | e2e |
 | `.mocharc.*` or `mocha` key in package.json | Mocha | unit |
@@ -222,7 +224,7 @@ CHECKPOINT: 2/4 complete, 2 remaining:
 |---|---|
 | Jest | `npx jest --ci --coverage --no-color` |
 | Vitest | `npx vitest run --coverage --reporter=verbose` |
-| pytest | `python -m pytest -v --tb=short --no-header --cov` |
+| pytest | `python -m pytest -v --tb=short --no-header` (add `--cov` only if pytest-cov is installed) |
 | Playwright | `npx playwright test --reporter=list` |
 | Cypress | `npx cypress run --reporter spec` |
 | Mocha | `npx mocha --reporter spec --no-color` |
@@ -233,7 +235,7 @@ CHECKPOINT: 2/4 complete, 2 remaining:
 | Locust | `locust --headless -u 1 -r 1 --run-time 30s` |
 | dotnet test | `dotnet test --no-build --verbosity normal` |
 
-Note: `--no-header` requires pytest >= 7.0. For older versions, remove this flag from the command.
+Note: `--no-header` requires pytest >= 7.0. For older versions, remove this flag. To check if pytest-cov is available, run `python -m pytest --co -q --cov 2>&1 | head -1` -- if it errors with "unrecognized arguments", omit `--cov`.
 
 Use the command resolution priority from Step 2b: project-specific scripts first, then named package.json scripts, then standard runner commands from the table above.
 

--- a/.factory/skills/test-all/SKILL.md
+++ b/.factory/skills/test-all/SKILL.md
@@ -138,26 +138,62 @@ If a service is `needs-setup`, ask the user whether to run setup commands before
 
 ### 4. Run Tests
 
-Execute ALL test types discovered in Step 2. Run them in this order (fastest first), but never skip any type:
+#### 4a. Build Execution Queue
 
-1. **Unit tests** - timeout 5 minutes per service
-2. **Integration tests** - timeout 10 minutes per service
-3. **Component tests** - timeout 10 minutes per service
-4. **E2E tests** - timeout 15 minutes per service
-5. **Performance tests** - timeout 10 minutes per service
+From the Step 2 discovery matrix, build an execution queue listing every service + test-type combination. Output it to the user before running anything:
 
-Execution rules:
+```
+EXECUTION QUEUE (N entries):
+[ ] unit       - Jest (services/api), pytest (services/worker)
+[ ] integration - pytest (services/worker)
+[ ] e2e        - Playwright (services/web)
+[ ] performance - k6 (services/api)
+```
 
-- CRITICAL: run every test type from the Step 2 discovery matrix. Do not stop after unit or integration tests -- always continue through component, e2e, and performance tests
-- For independent services, launch parallel execution (one per service)
+This queue is a binding contract. Every entry MUST be executed before generating the report.
+
+Execution order by type (fastest first):
+
+| Type | Timeout per service |
+|---|---|
+| unit | 5 minutes |
+| integration | 10 minutes |
+| component | 10 minutes |
+| e2e | 15 minutes |
+| performance | 10 minutes |
+
+#### 4b. Execute Queue (checkpoint loop)
+
+Process entries one by one. After completing each entry:
+
+1. Run the test command for this entry
+2. Record exit code, stdout/stderr, duration, coverage
+3. Mark entry as done with result (PASSED / FAILED / ERROR / TIMEOUT)
+4. Output checkpoint showing remaining queue:
+
+```
+CHECKPOINT: 2/4 complete, 2 remaining:
+[x] unit        - PASSED (42 passed, 0 failed)
+[x] integration - FAILED (8 passed, 3 failed)
+[ ] e2e         - pending
+[ ] performance - pending
+>>> Continuing with: e2e
+```
+
+5. Continue to next entry. NEVER stop the loop early.
+
+**CRITICAL**: do NOT generate the final report (Step 6) until ALL queue entries show `[x]`. If a test type fails, mark it as FAILED and move to the next entry. The loop ends only when every entry has been processed.
+
+#### 4c. Execution Rules
+
+- For independent services, launch parallel execution (one per service). Each track follows the same queue/checkpoint pattern for its service.
 - Within a service, run test types sequentially in the order above
 - Capture full stdout/stderr for each test run
-- Record exit code, duration, and any coverage output
 - If a test suite fails, continue with remaining suites in that service and other services
 - Pass `--no-color` or equivalent flag when available for clean output parsing
 - Use `--coverage` or equivalent when the runner supports it
 
-Common run commands by runner:
+#### 4d. Common Run Commands
 
 | Runner | Command |
 |---|---|
@@ -197,10 +233,20 @@ Aggregate results:
 - Per test type: total pass/fail/skip across all services
 - Overall: grand totals
 
-Verify completeness:
+Verify completeness before proceeding to Step 6:
 
-- Cross-reference executed test types against the Step 2 discovery matrix
-- If any discovered test type was not executed, flag it as "NOT RUN" in the report with explanation
+- Every entry from the Step 4a execution queue must have a result (PASSED / FAILED / ERROR / TIMEOUT)
+- If any entry is missing a result, go back and execute it now
+- Output the final completed queue as confirmation:
+
+```
+ALL QUEUE ENTRIES PROCESSED (4/4):
+[x] unit        - PASSED
+[x] integration - FAILED
+[x] e2e         - PASSED
+[x] performance - PASSED
+>>> Proceeding to report generation
+```
 
 ### 6. Generate Report
 

--- a/.factory/skills/test-all/SKILL.md
+++ b/.factory/skills/test-all/SKILL.md
@@ -138,7 +138,7 @@ If a service is `needs-setup`, ask the user whether to run setup commands before
 
 ### 4. Run Tests
 
-Execute tests in priority order (fastest first):
+Execute ALL test types discovered in Step 2. Run them in this order (fastest first), but never skip any type:
 
 1. **Unit tests** - timeout 5 minutes per service
 2. **Integration tests** - timeout 10 minutes per service
@@ -148,6 +148,7 @@ Execute tests in priority order (fastest first):
 
 Execution rules:
 
+- CRITICAL: run every test type from the Step 2 discovery matrix. Do not stop after unit or integration tests -- always continue through component, e2e, and performance tests
 - For independent services, launch parallel execution (one per service)
 - Within a service, run test types sequentially in the order above
 - Capture full stdout/stderr for each test run
@@ -195,6 +196,11 @@ Aggregate results:
 - Per service: total pass/fail/skip across all test types
 - Per test type: total pass/fail/skip across all services
 - Overall: grand totals
+
+Verify completeness:
+
+- Cross-reference executed test types against the Step 2 discovery matrix
+- If any discovered test type was not executed, flag it as "NOT RUN" in the report with explanation
 
 ### 6. Generate Report
 

--- a/.factory/skills/test-all/references/test-report-template.md
+++ b/.factory/skills/test-all/references/test-report-template.md
@@ -1,0 +1,103 @@
+# Test Run Report
+
+Use this structure for the final output.
+
+## 1. Summary
+
+| Metric | Value |
+|---|---|
+| Services tested | N |
+| Test suites run | N |
+| Total tests | N |
+| Passed | N |
+| Failed | N |
+| Skipped | N |
+| Total duration | Nm Ns |
+| Overall status | PASS / FAIL |
+
+## 2. Changed Services
+
+| Service | Path | Changed Files | Detection Method |
+|---|---|---|---|
+| api-service | `services/api/` | 12 | git diff vs main |
+| web-app | `services/web/` | 5 | git diff vs main |
+
+Detection method values:
+- `git diff vs <branch>`
+- `explicit path`
+- `--all flag`
+
+## 3. Environment Readiness
+
+| Service | Status | Issues | Fix Commands |
+|---|---|---|---|
+| api-service | ready | - | - |
+| web-app | needs-setup | node_modules missing | `cd services/web && npm install` |
+
+Status values:
+- `ready` - all prerequisites met
+- `needs-setup` - fixable issues with listed commands
+- `blocked` - critical dependency missing
+
+## 4. Test Results Matrix
+
+| Service | Unit | Integration | Component | E2E | Performance |
+|---|---|---|---|---|---|
+| api-service | 45/45 pass | 12/14 pass | - | - | - |
+| web-app | 89/90 pass | - | 15/15 pass | 8/8 pass | - |
+
+Cell format: `passed/total status` or `-` if test type not present.
+
+## 5. Failure Details
+
+### Service: `<service-name>`
+
+#### Test Type: `<type>`
+
+**Runner:** `<runner-name>` | **Command:** `<command-used>`
+
+| # | Test | File | Error |
+|---|---|---|---|
+| 1 | should validate email format | `src/validators/__tests__/email.test.ts:42` | Expected "valid" but received "invalid" |
+| 2 | should handle timeout | `src/api/__tests__/client.test.ts:88` | Timeout of 5000ms exceeded |
+
+<details>
+<summary>Full error output for test #N</summary>
+
+```
+Paste relevant error output here (first 20 lines).
+```
+
+</details>
+
+Repeat for each failing test type and service.
+
+## 6. Coverage Summary
+
+| Service | Lines | Branches | Functions | Statements |
+|---|---|---|---|---|
+| api-service | 78.5% | 65.2% | 82.1% | 79.0% |
+| web-app | 91.2% | 87.4% | 93.5% | 90.8% |
+
+Note: coverage data is only available when the test runner supports it and `--coverage` flag was used.
+If coverage is not available for a service, note "N/A" and explain why.
+
+## 7. Recommendations
+
+List actionable items based on the test run results:
+
+- **Missing test types**: services without integration/e2e tests
+- **Low coverage areas**: files or modules below threshold
+- **Flaky tests**: tests that show intermittent behavior (if detected)
+- **Environment improvements**: CI configuration suggestions
+- **New test suggestions**: uncovered code paths in changed files
+
+Format each recommendation as:
+
+| Priority | Service | Recommendation | Rationale |
+|---|---|---|---|
+| high | api-service | Add integration tests for new endpoint | Endpoint `/api/v2/users` has no integration coverage |
+| medium | web-app | Fix flaky timeout test | `client.test.ts:88` failed with timeout |
+| low | web-app | Increase branch coverage | Branch coverage 65.2% is below 80% threshold |
+
+Priority values: `critical`, `high`, `medium`, `low`.

--- a/.github/skills/test-all/SKILL.md
+++ b/.github/skills/test-all/SKILL.md
@@ -36,9 +36,11 @@ git diff --name-only <base-branch>...HEAD 2>/dev/null || true
 git diff --name-only
 # Staged changes
 git diff --name-only --cached
+# Untracked files (new files not yet staged)
+git ls-files --others --exclude-standard
 ```
 
-Combine all changed file paths. Map each changed file to its parent service directory. A service directory is identified by the presence of a project manifest at its root:
+Combine all changed file paths (including untracked). Map each changed file to its parent service directory. A service directory is identified by the presence of a project manifest at its root:
 
 - `package.json` (Node.js / frontend)
 - `pyproject.toml` or `setup.py` or `setup.cfg` (Python)
@@ -62,7 +64,7 @@ For each affected service, scan for test runner configurations and classify test
 |---|---|---|
 | `jest.config.*` or `jest` key in package.json | Jest | unit |
 | `vitest.config.*` | Vitest | unit |
-| `pytest.ini` / `pyproject.toml` with `[tool.pytest]` / `conftest.py` | pytest | unit |
+| `pytest.ini` / `pyproject.toml` with `[tool.pytest.ini_options]` / `conftest.py` | pytest | unit |
 | `playwright.config.*` | Playwright | e2e |
 | `cypress.config.*` or `cypress/` directory | Cypress | e2e |
 | `.mocharc.*` or `mocha` key in package.json | Mocha | unit |
@@ -223,7 +225,7 @@ CHECKPOINT: 2/4 complete, 2 remaining:
 |---|---|
 | Jest | `npx jest --ci --coverage --no-color` |
 | Vitest | `npx vitest run --coverage --reporter=verbose` |
-| pytest | `python -m pytest -v --tb=short --no-header --cov` |
+| pytest | `python -m pytest -v --tb=short --no-header` (add `--cov` only if pytest-cov is installed) |
 | Playwright | `npx playwright test --reporter=list` |
 | Cypress | `npx cypress run --reporter spec` |
 | Mocha | `npx mocha --reporter spec --no-color` |
@@ -234,7 +236,7 @@ CHECKPOINT: 2/4 complete, 2 remaining:
 | Locust | `locust --headless -u 1 -r 1 --run-time 30s` |
 | dotnet test | `dotnet test --no-build --verbosity normal` |
 
-Note: `--no-header` requires pytest >= 7.0. For older versions, remove this flag from the command.
+Note: `--no-header` requires pytest >= 7.0. For older versions, remove this flag. To check if pytest-cov is available, run `python -m pytest --co -q --cov 2>&1 | head -1` -- if it errors with "unrecognized arguments", omit `--cov`.
 
 Use the command resolution priority from Step 2b: project-specific scripts first, then named package.json scripts, then standard runner commands from the table above.
 

--- a/.github/skills/test-all/SKILL.md
+++ b/.github/skills/test-all/SKILL.md
@@ -139,26 +139,62 @@ If a service is `needs-setup`, ask the user whether to run setup commands before
 
 ### 4. Run Tests
 
-Execute ALL test types discovered in Step 2. Run them in this order (fastest first), but never skip any type:
+#### 4a. Build Execution Queue
 
-1. **Unit tests** - timeout 5 minutes per service
-2. **Integration tests** - timeout 10 minutes per service
-3. **Component tests** - timeout 10 minutes per service
-4. **E2E tests** - timeout 15 minutes per service
-5. **Performance tests** - timeout 10 minutes per service
+From the Step 2 discovery matrix, build an execution queue listing every service + test-type combination. Output it to the user before running anything:
 
-Execution rules:
+```
+EXECUTION QUEUE (N entries):
+[ ] unit       - Jest (services/api), pytest (services/worker)
+[ ] integration - pytest (services/worker)
+[ ] e2e        - Playwright (services/web)
+[ ] performance - k6 (services/api)
+```
 
-- CRITICAL: run every test type from the Step 2 discovery matrix. Do not stop after unit or integration tests -- always continue through component, e2e, and performance tests
-- For independent services, launch parallel execution
+This queue is a binding contract. Every entry MUST be executed before generating the report.
+
+Execution order by type (fastest first):
+
+| Type | Timeout per service |
+|---|---|
+| unit | 5 minutes |
+| integration | 10 minutes |
+| component | 10 minutes |
+| e2e | 15 minutes |
+| performance | 10 minutes |
+
+#### 4b. Execute Queue (checkpoint loop)
+
+Process entries one by one. After completing each entry:
+
+1. Run the test command for this entry
+2. Record exit code, stdout/stderr, duration, coverage
+3. Mark entry as done with result (PASSED / FAILED / ERROR / TIMEOUT)
+4. Output checkpoint showing remaining queue:
+
+```
+CHECKPOINT: 2/4 complete, 2 remaining:
+[x] unit        - PASSED (42 passed, 0 failed)
+[x] integration - FAILED (8 passed, 3 failed)
+[ ] e2e         - pending
+[ ] performance - pending
+>>> Continuing with: e2e
+```
+
+5. Continue to next entry. NEVER stop the loop early.
+
+**CRITICAL**: do NOT generate the final report (Step 6) until ALL queue entries show `[x]`. If a test type fails, mark it as FAILED and move to the next entry. The loop ends only when every entry has been processed.
+
+#### 4c. Execution Rules
+
+- For independent services, launch parallel execution. Each track follows the same queue/checkpoint pattern for its service.
 - Within a service, run test types sequentially in the order above
 - Capture full stdout/stderr for each test run
-- Record exit code, duration, and any coverage output
 - If a test suite fails, continue with remaining suites in that service and other services
 - Pass `--no-color` or equivalent flag when available for clean output parsing
 - Use `--coverage` or equivalent when the runner supports it
 
-Common run commands by runner:
+#### 4d. Common Run Commands
 
 | Runner | Command |
 |---|---|
@@ -198,10 +234,20 @@ Aggregate results:
 - Per test type: total pass/fail/skip across all services
 - Overall: grand totals
 
-Verify completeness:
+Verify completeness before proceeding to Step 6:
 
-- Cross-reference executed test types against the Step 2 discovery matrix
-- If any discovered test type was not executed, flag it as "NOT RUN" in the report with explanation
+- Every entry from the Step 4a execution queue must have a result (PASSED / FAILED / ERROR / TIMEOUT)
+- If any entry is missing a result, go back and execute it now
+- Output the final completed queue as confirmation:
+
+```
+ALL QUEUE ENTRIES PROCESSED (4/4):
+[x] unit        - PASSED
+[x] integration - FAILED
+[x] e2e         - PASSED
+[x] performance - PASSED
+>>> Proceeding to report generation
+```
 
 ### 6. Generate Report
 

--- a/.github/skills/test-all/SKILL.md
+++ b/.github/skills/test-all/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: test-all
+description: Detect modified services in a monorepo, discover all test types (unit, integration, component, e2e, performance), validate environment readiness, run tests, and produce a structured report. Use when you need to run all applicable tests after code changes.
+argument-hint: "[service-path or --all] [--base-branch=main]"
+license: MIT
+---
+
+# Test All
+
+## Goal
+
+Automatically detect changed services, discover all available test suites, validate environment readiness, execute tests, and produce a structured report.
+
+## Required Inputs
+
+Collect before execution:
+
+- Repository root path (default: current working directory)
+- Base branch for diff comparison (default: `main`, override with `--base-branch=<branch>`)
+- Scope: auto-detect from git changes, explicit service paths, or `--all` for full run
+
+If `$ARGUMENTS` contains paths, use those as explicit service targets.
+If `$ARGUMENTS` contains `--all`, scan every service in the monorepo.
+Otherwise, auto-detect affected services from git changes.
+
+## Workflow
+
+### 1. Detect Changed Services
+
+Identify which services have been modified:
+
+```bash
+# All changes in current branch vs base
+git diff --name-only <base-branch>...HEAD 2>/dev/null || true
+# Unstaged changes
+git diff --name-only
+# Staged changes
+git diff --name-only --cached
+```
+
+Combine all changed file paths. Map each changed file to its parent service directory. A service directory is identified by the presence of a project manifest at its root:
+
+- `package.json` (Node.js / frontend)
+- `pyproject.toml` or `setup.py` or `setup.cfg` (Python)
+- `go.mod` (Go)
+- `pom.xml` or `build.gradle` or `build.gradle.kts` (Java/Kotlin)
+- `Cargo.toml` (Rust)
+- `Gemfile` (Ruby)
+- `composer.json` (PHP)
+- `Makefile` with test targets (generic)
+
+If the repository root itself is a single-service project (manifest at root level), treat the entire repo as one service.
+
+Report the list of affected services with the count of changed files per service.
+
+### 2. Discover Test Configurations
+
+For each affected service, scan for test runner configurations and classify test types:
+
+| Marker | Runner | Default Type |
+|---|---|---|
+| `jest.config.*` or `jest` key in package.json | Jest | unit |
+| `vitest.config.*` | Vitest | unit |
+| `pytest.ini` / `pyproject.toml` with `[tool.pytest]` / `conftest.py` | pytest | unit |
+| `playwright.config.*` | Playwright | e2e |
+| `cypress.config.*` or `cypress/` directory | Cypress | e2e |
+| `.mocharc.*` or `mocha` key in package.json | Mocha | unit |
+| `*_test.go` files | go test | unit |
+| `src/test/` + `pom.xml` | Maven (JUnit) | unit |
+| `src/test/` + `build.gradle*` | Gradle (JUnit) | unit |
+| `k6/` scripts or `*.k6.js` | k6 | performance |
+| `locustfile.py` or `locust/` | Locust | performance |
+| `artillery.yml` or `.artillery/` | Artillery | performance |
+
+Additionally, check `package.json` scripts for named test commands:
+
+- `test` or `test:unit` -> unit
+- `test:integration` or `test:int` -> integration
+- `test:component` -> component
+- `test:e2e` or `test:playwright` or `test:cypress` -> e2e
+- `test:perf` or `test:performance` or `test:load` -> performance
+- `test:all` -> all types
+
+For Python projects, check for directory conventions:
+
+- `tests/unit/` or `tests/test_*.py` at root -> unit
+- `tests/integration/` -> integration
+- `tests/e2e/` -> e2e
+- `tests/performance/` or `tests/load/` -> performance
+
+For Go projects, check for:
+
+- `*_test.go` in source directories -> unit
+- `tests/integration/` or `_integration_test.go` suffix -> integration
+- `tests/e2e/` -> e2e
+
+Produce a matrix: service x test-type with runner commands.
+
+### 3. Validate Environment Readiness
+
+For each service, check prerequisites:
+
+**Node.js services:**
+- `node_modules/` exists -> if not, suggest `npm install` / `yarn install` / `pnpm install`
+- Check for lockfile to determine package manager (package-lock.json / yarn.lock / pnpm-lock.yaml)
+- `.env` or `.env.test` exists if referenced in configs
+
+**Python services:**
+- Virtual environment exists (`.venv/`, `venv/`, or active conda env)
+- Dependencies installed (check for `requirements.txt`, `pyproject.toml` with deps)
+- Test dependencies present (pytest in installed packages)
+
+**Go services:**
+- `go.sum` exists (modules downloaded)
+- Build succeeds (`go build ./...`)
+
+**Java/Kotlin services:**
+- Build tool wrapper exists (`mvnw`, `gradlew`)
+- Dependencies cached (`~/.m2/repository` or `.gradle/`)
+
+**Integration/E2E prerequisites:**
+- Docker running (if docker-compose.yml or Dockerfile present in test config)
+- Test database available (check env vars like DATABASE_URL, TEST_DATABASE_URL)
+- Required services running (check ports or health endpoints if configured)
+
+Classify each service:
+
+- `ready` - all prerequisites met, tests can run immediately
+- `needs-setup` - missing prerequisites with specific fix commands
+- `blocked` - critical dependency missing that cannot be auto-resolved
+
+If a service is `needs-setup`, ask the user whether to run setup commands before continuing.
+
+### 4. Run Tests
+
+Execute tests in priority order (fastest first):
+
+1. **Unit tests** - timeout 5 minutes per service
+2. **Integration tests** - timeout 10 minutes per service
+3. **Component tests** - timeout 10 minutes per service
+4. **E2E tests** - timeout 15 minutes per service
+5. **Performance tests** - timeout 10 minutes per service
+
+Execution rules:
+
+- For independent services, launch parallel execution
+- Within a service, run test types sequentially in the order above
+- Capture full stdout/stderr for each test run
+- Record exit code, duration, and any coverage output
+- If a test suite fails, continue with remaining suites in that service and other services
+- Pass `--no-color` or equivalent flag when available for clean output parsing
+- Use `--coverage` or equivalent when the runner supports it
+
+Common run commands by runner:
+
+| Runner | Command |
+|---|---|
+| Jest | `npx jest --ci --coverage --no-color` |
+| Vitest | `npx vitest run --coverage --reporter=verbose` |
+| pytest | `python -m pytest -v --tb=short --no-header` |
+| Playwright | `npx playwright test --reporter=list` |
+| Cypress | `npx cypress run --reporter spec` |
+| Mocha | `npx mocha --reporter spec --no-color` |
+| go test | `go test -v -count=1 ./...` |
+| Maven | `./mvnw test -B` |
+| Gradle | `./gradlew test` |
+| k6 | `k6 run --summary-trend-stats="avg,p(95),p(99)" <script>` |
+| Locust | `locust --headless -u 1 -r 1 --run-time 30s` |
+
+If `package.json` has specific named scripts (e.g., `test:unit`, `test:e2e`), prefer those over generic runner commands as they may include project-specific configuration.
+
+### 5. Collect and Parse Results
+
+For each test run, extract:
+
+- Total tests: passed / failed / skipped / errored
+- Duration in seconds
+- Coverage percentage (line, branch, function) if available
+- List of failed tests with:
+  - Test file path
+  - Test name / describe block
+  - Error message (first 10 lines)
+  - Stack trace hint (file:line of assertion failure)
+
+Aggregate results:
+
+- Per service: total pass/fail/skip across all test types
+- Per test type: total pass/fail/skip across all services
+- Overall: grand totals
+
+### 6. Generate Report
+
+Write the report to stdout using `references/test-report-template.md` as the structure.
+
+Include:
+
+- Executive summary with overall pass/fail status
+- Per-service breakdown
+- Failure details with actionable context
+- Environment issues encountered
+- Recommendations for improving test coverage
+
+## Parallel Execution Strategy
+
+When multiple services are affected:
+
+- Launch one parallel track per service for independent test execution
+- Each track runs all discovered test types for its assigned service
+- Main process collects results and assembles the final report
+- If only one service is affected, run sequentially
+
+## Error Handling
+
+| Situation | Behavior |
+|---|---|
+| No git repository | Error: report and exit |
+| No changed files detected | Info: suggest `--all` flag or explicit paths |
+| No tests found in service | Warning: report service as "no tests configured" |
+| Test runner not installed | `needs-setup`: suggest install command |
+| Test timeout exceeded | Kill process, report as timeout failure |
+| Environment variable missing | `needs-setup`: list required vars |
+| Docker not running | `blocked` for integration/e2e that need it |
+
+## Output Contract
+
+Always produce a report using `references/test-report-template.md` structure containing:
+
+- Changed services detection summary
+- Environment readiness matrix
+- Test results matrix (service x test-type)
+- Failure details with file paths and error messages
+- Coverage summary per service (when available)
+- Actionable recommendations
+
+## Prompt Template
+
+Invoke the skill with optional arguments:
+
+```text
+/test-all $ARGUMENTS
+```
+
+Where `$ARGUMENTS` can be:
+
+- Empty: auto-detect changed services from git, use `main` as base branch
+- `--all`: run tests for all services
+- `--base-branch=develop`: use `develop` as comparison branch
+- `services/api services/web`: explicit service paths
+- Combinations: `services/api --base-branch=develop`
+
+Default user prompt after parsing arguments:
+
+```text
+Run all applicable tests for modified services in this monorepo.
+Detect which services changed, discover test types, validate the environment, execute tests, and produce a structured report.
+```

--- a/.github/skills/test-all/SKILL.md
+++ b/.github/skills/test-all/SKILL.md
@@ -47,6 +47,7 @@ Combine all changed file paths. Map each changed file to its parent service dire
 - `Cargo.toml` (Rust)
 - `Gemfile` (Ruby)
 - `composer.json` (PHP)
+- `*.csproj` or `*.sln` (.NET / C#)
 - `Makefile` with test targets (generic)
 
 If the repository root itself is a single-service project (manifest at root level), treat the entire repo as one service.
@@ -71,6 +72,7 @@ For each affected service, scan for test runner configurations and classify test
 | `k6/` scripts or `*.k6.js` | k6 | performance |
 | `locustfile.py` or `locust/` | Locust | performance |
 | `artillery.yml` or `.artillery/` | Artillery | performance |
+| `*.csproj` + `*Tests` project | dotnet test | unit |
 
 Additionally, check `package.json` scripts for named test commands:
 
@@ -101,8 +103,8 @@ Produce a matrix: service x test-type with runner commands.
 For each service, check prerequisites:
 
 **Node.js services:**
-- `node_modules/` exists -> if not, suggest `npm install` / `yarn install` / `pnpm install`
-- Check for lockfile to determine package manager (package-lock.json / yarn.lock / pnpm-lock.yaml)
+- `node_modules/` exists -> if not, suggest `npm install` / `yarn install` / `pnpm install` / `bun install`
+- Check for lockfile to determine package manager (package-lock.json / yarn.lock / pnpm-lock.yaml / bun.lock)
 - `.env` or `.env.test` exists if referenced in configs
 
 **Python services:**
@@ -112,11 +114,15 @@ For each service, check prerequisites:
 
 **Go services:**
 - `go.sum` exists (modules downloaded)
-- Build succeeds (`go build ./...`)
+- Source valid (`go vet ./...`)
 
 **Java/Kotlin services:**
 - Build tool wrapper exists (`mvnw`, `gradlew`)
 - Dependencies cached (`~/.m2/repository` or `.gradle/`)
+
+**.NET services:**
+- .NET SDK installed (`dotnet --version`)
+- Dependencies restored (`dotnet restore` if `obj/` missing)
 
 **Integration/E2E prerequisites:**
 - Docker running (if docker-compose.yml or Dockerfile present in test config)
@@ -157,7 +163,7 @@ Common run commands by runner:
 |---|---|
 | Jest | `npx jest --ci --coverage --no-color` |
 | Vitest | `npx vitest run --coverage --reporter=verbose` |
-| pytest | `python -m pytest -v --tb=short --no-header` |
+| pytest | `python -m pytest -v --tb=short --no-header --cov` |
 | Playwright | `npx playwright test --reporter=list` |
 | Cypress | `npx cypress run --reporter spec` |
 | Mocha | `npx mocha --reporter spec --no-color` |
@@ -166,6 +172,9 @@ Common run commands by runner:
 | Gradle | `./gradlew test` |
 | k6 | `k6 run --summary-trend-stats="avg,p(95),p(99)" <script>` |
 | Locust | `locust --headless -u 1 -r 1 --run-time 30s` |
+| dotnet test | `dotnet test --no-build --verbosity normal` |
+
+Note: `--no-header` requires pytest >= 7.0. For older versions, remove this flag from the command.
 
 If `package.json` has specific named scripts (e.g., `test:unit`, `test:e2e`), prefer those over generic runner commands as they may include project-specific configuration.
 

--- a/.github/skills/test-all/SKILL.md
+++ b/.github/skills/test-all/SKILL.md
@@ -139,7 +139,7 @@ If a service is `needs-setup`, ask the user whether to run setup commands before
 
 ### 4. Run Tests
 
-Execute tests in priority order (fastest first):
+Execute ALL test types discovered in Step 2. Run them in this order (fastest first), but never skip any type:
 
 1. **Unit tests** - timeout 5 minutes per service
 2. **Integration tests** - timeout 10 minutes per service
@@ -149,6 +149,7 @@ Execute tests in priority order (fastest first):
 
 Execution rules:
 
+- CRITICAL: run every test type from the Step 2 discovery matrix. Do not stop after unit or integration tests -- always continue through component, e2e, and performance tests
 - For independent services, launch parallel execution
 - Within a service, run test types sequentially in the order above
 - Capture full stdout/stderr for each test run
@@ -196,6 +197,11 @@ Aggregate results:
 - Per service: total pass/fail/skip across all test types
 - Per test type: total pass/fail/skip across all services
 - Overall: grand totals
+
+Verify completeness:
+
+- Cross-reference executed test types against the Step 2 discovery matrix
+- If any discovered test type was not executed, flag it as "NOT RUN" in the report with explanation
 
 ### 6. Generate Report
 

--- a/.github/skills/test-all/SKILL.md
+++ b/.github/skills/test-all/SKILL.md
@@ -98,6 +98,29 @@ For Go projects, check for:
 
 Produce a matrix: service x test-type with runner commands.
 
+#### 2b. Discover Project-Specific Test Scripts
+
+Before falling back to standard runner commands, search each service for custom test scripts that the team may have configured. These take priority over generic commands because they often include project-specific flags, environment setup, or multi-step workflows.
+
+Search locations (in priority order):
+
+1. **Makefile / Taskfile.yml / justfile** -- look for targets like `test`, `test-unit`, `test-integration`, `test-e2e`, `test-perf`, `test-all`, `check`, `ci-test`
+2. **Shell scripts** -- `scripts/test*.sh`, `bin/test*`, `run-tests.sh`, `ci/*.sh`
+3. **package.json scripts** (Node.js) -- `test`, `test:unit`, `test:integration`, `test:e2e`, `test:perf`, `test:all`
+4. **pyproject.toml / tox.ini / noxfile.py** (Python) -- `[tool.tox]` envs, nox sessions like `tests`, `integration`, `e2e`
+5. **Docker Compose test services** -- `docker-compose.test.yml`, services named `*-test*`
+6. **CI config files** -- `.github/workflows/test*.yml`, `Jenkinsfile`, `.gitlab-ci.yml` -- extract test commands from CI steps as hints for local execution
+
+For each discovered script, map it to a test type (unit / integration / e2e / performance) based on name or content.
+
+**Command resolution priority** for each test type in a service:
+
+1. Project-specific script (Makefile target, shell script, tox env, etc.)
+2. Named `package.json` script (e.g., `test:e2e`)
+3. Standard runner command from the table in Step 4d
+
+Record the chosen command source in the execution queue (e.g., `Makefile:test-e2e` vs `npx playwright test`).
+
 ### 3. Validate Environment Readiness
 
 For each service, check prerequisites:
@@ -145,10 +168,10 @@ From the Step 2 discovery matrix, build an execution queue listing every service
 
 ```
 EXECUTION QUEUE (N entries):
-[ ] unit       - Jest (services/api), pytest (services/worker)
-[ ] integration - pytest (services/worker)
-[ ] e2e        - Playwright (services/web)
-[ ] performance - k6 (services/api)
+[ ] unit        - services/api (npm test:unit via package.json), services/worker (make test-unit via Makefile)
+[ ] integration - services/worker (python -m pytest tests/integration/ --cov, standard)
+[ ] e2e         - services/web (scripts/run-e2e.sh via shell script)
+[ ] performance - services/api (k6 run ..., standard)
 ```
 
 This queue is a binding contract. Every entry MUST be executed before generating the report.
@@ -213,7 +236,7 @@ CHECKPOINT: 2/4 complete, 2 remaining:
 
 Note: `--no-header` requires pytest >= 7.0. For older versions, remove this flag from the command.
 
-If `package.json` has specific named scripts (e.g., `test:unit`, `test:e2e`), prefer those over generic runner commands as they may include project-specific configuration.
+Use the command resolution priority from Step 2b: project-specific scripts first, then named package.json scripts, then standard runner commands from the table above.
 
 ### 5. Collect and Parse Results
 

--- a/.github/skills/test-all/references/test-report-template.md
+++ b/.github/skills/test-all/references/test-report-template.md
@@ -1,0 +1,103 @@
+# Test Run Report
+
+Use this structure for the final output.
+
+## 1. Summary
+
+| Metric | Value |
+|---|---|
+| Services tested | N |
+| Test suites run | N |
+| Total tests | N |
+| Passed | N |
+| Failed | N |
+| Skipped | N |
+| Total duration | Nm Ns |
+| Overall status | PASS / FAIL |
+
+## 2. Changed Services
+
+| Service | Path | Changed Files | Detection Method |
+|---|---|---|---|
+| api-service | `services/api/` | 12 | git diff vs main |
+| web-app | `services/web/` | 5 | git diff vs main |
+
+Detection method values:
+- `git diff vs <branch>`
+- `explicit path`
+- `--all flag`
+
+## 3. Environment Readiness
+
+| Service | Status | Issues | Fix Commands |
+|---|---|---|---|
+| api-service | ready | - | - |
+| web-app | needs-setup | node_modules missing | `cd services/web && npm install` |
+
+Status values:
+- `ready` - all prerequisites met
+- `needs-setup` - fixable issues with listed commands
+- `blocked` - critical dependency missing
+
+## 4. Test Results Matrix
+
+| Service | Unit | Integration | Component | E2E | Performance |
+|---|---|---|---|---|---|
+| api-service | 45/45 pass | 12/14 pass | - | - | - |
+| web-app | 89/90 pass | - | 15/15 pass | 8/8 pass | - |
+
+Cell format: `passed/total status` or `-` if test type not present.
+
+## 5. Failure Details
+
+### Service: `<service-name>`
+
+#### Test Type: `<type>`
+
+**Runner:** `<runner-name>` | **Command:** `<command-used>`
+
+| # | Test | File | Error |
+|---|---|---|---|
+| 1 | should validate email format | `src/validators/__tests__/email.test.ts:42` | Expected "valid" but received "invalid" |
+| 2 | should handle timeout | `src/api/__tests__/client.test.ts:88` | Timeout of 5000ms exceeded |
+
+<details>
+<summary>Full error output for test #N</summary>
+
+```
+Paste relevant error output here (first 20 lines).
+```
+
+</details>
+
+Repeat for each failing test type and service.
+
+## 6. Coverage Summary
+
+| Service | Lines | Branches | Functions | Statements |
+|---|---|---|---|---|
+| api-service | 78.5% | 65.2% | 82.1% | 79.0% |
+| web-app | 91.2% | 87.4% | 93.5% | 90.8% |
+
+Note: coverage data is only available when the test runner supports it and `--coverage` flag was used.
+If coverage is not available for a service, note "N/A" and explain why.
+
+## 7. Recommendations
+
+List actionable items based on the test run results:
+
+- **Missing test types**: services without integration/e2e tests
+- **Low coverage areas**: files or modules below threshold
+- **Flaky tests**: tests that show intermittent behavior (if detected)
+- **Environment improvements**: CI configuration suggestions
+- **New test suggestions**: uncovered code paths in changed files
+
+Format each recommendation as:
+
+| Priority | Service | Recommendation | Rationale |
+|---|---|---|---|
+| high | api-service | Add integration tests for new endpoint | Endpoint `/api/v2/users` has no integration coverage |
+| medium | web-app | Fix flaky timeout test | `client.test.ts:88` failed with timeout |
+| low | web-app | Increase branch coverage | Branch coverage 65.2% is below 80% threshold |
+
+Priority values: `critical`, `high`, `medium`, `low`.

--- a/.opencode/README.md
+++ b/.opencode/README.md
@@ -19,10 +19,14 @@ This directory contains OpenCode CLI agents and commands, migrated from Claude C
 │   │   ├── SKILL.md
 │   │   └── scripts/
 │   │       └── worktree.sh
-│   └── jira-parallel-execution-planner/  # Jira planning skill (model-invocation)
+│   ├── jira-parallel-execution-planner/  # Jira planning skill (model-invocation)
+│   │   ├── SKILL.md
+│   │   └── references/
+│   │       └── analysis-checklist.md
+│   └── test-all/            # Test discovery and execution (model-invocation)
 │       ├── SKILL.md
 │       └── references/
-│           └── analysis-checklist.md
+│           └── test-report-template.md
 └── README.md                # This file
 ```
 
@@ -469,6 +473,26 @@ Analyze a Jira task and its dependency graph, validate execution sequence and pa
 6. Builds parallel subagent execution plan with ownership boundaries
 
 **Output structure:** Uses `references/analysis-checklist.md` template with sections for dependency map, parallelization validation, codebase readiness matrix, implementation plan, and subagent plan.
+
+#### `/test-all` - Automated Test Discovery and Execution
+
+Detect modified services, discover all test types, validate environment readiness, run tests, and produce a structured report.
+
+**Usage:**
+```bash
+/test-all
+/test-all --all
+/test-all services/api --base-branch=develop
+```
+
+**What it does:**
+1. Detects changed services via git diff
+2. Discovers test configurations (jest, vitest, pytest, playwright, etc.)
+3. Validates environment readiness (dependencies, configs, Docker)
+4. Runs tests in priority order (unit -> integration -> component -> e2e -> performance)
+5. Produces structured report with results matrix, failures, coverage
+
+**Output structure:** Uses `references/test-report-template.md` template with summary, results matrix, failure details, coverage, and recommendations.
 
 ### Skills Discovery
 

--- a/.opencode/skills/test-all/SKILL.md
+++ b/.opencode/skills/test-all/SKILL.md
@@ -140,25 +140,61 @@ If a service is `needs-setup`, ask the user whether to run setup commands before
 
 ### 4. Run Tests
 
-Execute ALL test types discovered in Step 2. Run them in this order (fastest first), but never skip any type:
+#### 4a. Build Execution Queue
 
-1. **Unit tests** - timeout 5 minutes per service
-2. **Integration tests** - timeout 10 minutes per service
-3. **Component tests** - timeout 10 minutes per service
-4. **E2E tests** - timeout 15 minutes per service
-5. **Performance tests** - timeout 10 minutes per service
+From the Step 2 discovery matrix, build an execution queue listing every service + test-type combination. Output it to the user before running anything:
 
-Execution rules:
+```
+EXECUTION QUEUE (N entries):
+[ ] unit       - Jest (services/api), pytest (services/worker)
+[ ] integration - pytest (services/worker)
+[ ] e2e        - Playwright (services/web)
+[ ] performance - k6 (services/api)
+```
 
-- CRITICAL: run every test type from the Step 2 discovery matrix. Do not stop after unit or integration tests -- always continue through component, e2e, and performance tests
+This queue is a binding contract. Every entry MUST be executed before generating the report.
+
+Execution order by type (fastest first):
+
+| Type | Timeout per service |
+|---|---|
+| unit | 5 minutes |
+| integration | 10 minutes |
+| component | 10 minutes |
+| e2e | 15 minutes |
+| performance | 10 minutes |
+
+#### 4b. Execute Queue (checkpoint loop)
+
+Process entries one by one. After completing each entry:
+
+1. Run the test command for this entry
+2. Record exit code, stdout/stderr, duration, coverage
+3. Mark entry as done with result (PASSED / FAILED / ERROR / TIMEOUT)
+4. Output checkpoint showing remaining queue:
+
+```
+CHECKPOINT: 2/4 complete, 2 remaining:
+[x] unit        - PASSED (42 passed, 0 failed)
+[x] integration - FAILED (8 passed, 3 failed)
+[ ] e2e         - pending
+[ ] performance - pending
+>>> Continuing with: e2e
+```
+
+5. Continue to next entry. NEVER stop the loop early.
+
+**CRITICAL**: do NOT generate the final report (Step 6) until ALL queue entries show `[x]`. If a test type fails, mark it as FAILED and move to the next entry. The loop ends only when every entry has been processed.
+
+#### 4c. Execution Rules
+
 - Within a service, run test types sequentially in the order above
 - Capture full stdout/stderr for each test run
-- Record exit code, duration, and any coverage output
 - If a test suite fails, continue with remaining suites in that service and other services
 - Pass `--no-color` or equivalent flag when available for clean output parsing
 - Use `--coverage` or equivalent when the runner supports it
 
-Common run commands by runner:
+#### 4d. Common Run Commands
 
 | Runner | Command |
 |---|---|
@@ -198,10 +234,20 @@ Aggregate results:
 - Per test type: total pass/fail/skip across all services
 - Overall: grand totals
 
-Verify completeness:
+Verify completeness before proceeding to Step 6:
 
-- Cross-reference executed test types against the Step 2 discovery matrix
-- If any discovered test type was not executed, flag it as "NOT RUN" in the report with explanation
+- Every entry from the Step 4a execution queue must have a result (PASSED / FAILED / ERROR / TIMEOUT)
+- If any entry is missing a result, go back and execute it now
+- Output the final completed queue as confirmation:
+
+```
+ALL QUEUE ENTRIES PROCESSED (4/4):
+[x] unit        - PASSED
+[x] integration - FAILED
+[x] e2e         - PASSED
+[x] performance - PASSED
+>>> Proceeding to report generation
+```
 
 ### 6. Generate Report
 

--- a/.opencode/skills/test-all/SKILL.md
+++ b/.opencode/skills/test-all/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: test-all
+description: Detect modified services in a monorepo, discover all test types (unit, integration, component, e2e, performance), validate environment readiness, run tests, and produce a structured report. Use when you need to run all applicable tests after code changes.
+argument-hint: "[service-path or --all] [--base-branch=main]"
+license: MIT
+compatibility: opencode
+---
+
+# Test All
+
+## Goal
+
+Automatically detect changed services, discover all available test suites, validate environment readiness, execute tests, and produce a structured report.
+
+## Required Inputs
+
+Collect before execution:
+
+- Repository root path (default: current working directory)
+- Base branch for diff comparison (default: `main`, override with `--base-branch=<branch>`)
+- Scope: auto-detect from git changes, explicit service paths, or `--all` for full run
+
+If `$ARGUMENTS` contains paths, use those as explicit service targets.
+If `$ARGUMENTS` contains `--all`, scan every service in the monorepo.
+Otherwise, auto-detect affected services from git changes.
+
+## Workflow
+
+### 1. Detect Changed Services
+
+Identify which services have been modified:
+
+```bash
+# All changes in current branch vs base
+git diff --name-only <base-branch>...HEAD 2>/dev/null || true
+# Unstaged changes
+git diff --name-only
+# Staged changes
+git diff --name-only --cached
+```
+
+Combine all changed file paths. Map each changed file to its parent service directory. A service directory is identified by the presence of a project manifest at its root:
+
+- `package.json` (Node.js / frontend)
+- `pyproject.toml` or `setup.py` or `setup.cfg` (Python)
+- `go.mod` (Go)
+- `pom.xml` or `build.gradle` or `build.gradle.kts` (Java/Kotlin)
+- `Cargo.toml` (Rust)
+- `Gemfile` (Ruby)
+- `composer.json` (PHP)
+- `Makefile` with test targets (generic)
+
+If the repository root itself is a single-service project (manifest at root level), treat the entire repo as one service.
+
+Report the list of affected services with the count of changed files per service.
+
+### 2. Discover Test Configurations
+
+For each affected service, scan for test runner configurations and classify test types:
+
+| Marker | Runner | Default Type |
+|---|---|---|
+| `jest.config.*` or `jest` key in package.json | Jest | unit |
+| `vitest.config.*` | Vitest | unit |
+| `pytest.ini` / `pyproject.toml` with `[tool.pytest]` / `conftest.py` | pytest | unit |
+| `playwright.config.*` | Playwright | e2e |
+| `cypress.config.*` or `cypress/` directory | Cypress | e2e |
+| `.mocharc.*` or `mocha` key in package.json | Mocha | unit |
+| `*_test.go` files | go test | unit |
+| `src/test/` + `pom.xml` | Maven (JUnit) | unit |
+| `src/test/` + `build.gradle*` | Gradle (JUnit) | unit |
+| `k6/` scripts or `*.k6.js` | k6 | performance |
+| `locustfile.py` or `locust/` | Locust | performance |
+| `artillery.yml` or `.artillery/` | Artillery | performance |
+
+Additionally, check `package.json` scripts for named test commands:
+
+- `test` or `test:unit` -> unit
+- `test:integration` or `test:int` -> integration
+- `test:component` -> component
+- `test:e2e` or `test:playwright` or `test:cypress` -> e2e
+- `test:perf` or `test:performance` or `test:load` -> performance
+- `test:all` -> all types
+
+For Python projects, check for directory conventions:
+
+- `tests/unit/` or `tests/test_*.py` at root -> unit
+- `tests/integration/` -> integration
+- `tests/e2e/` -> e2e
+- `tests/performance/` or `tests/load/` -> performance
+
+For Go projects, check for:
+
+- `*_test.go` in source directories -> unit
+- `tests/integration/` or `_integration_test.go` suffix -> integration
+- `tests/e2e/` -> e2e
+
+Produce a matrix: service x test-type with runner commands.
+
+### 3. Validate Environment Readiness
+
+For each service, check prerequisites:
+
+**Node.js services:**
+- `node_modules/` exists -> if not, suggest `npm install` / `yarn install` / `pnpm install`
+- Check for lockfile to determine package manager (package-lock.json / yarn.lock / pnpm-lock.yaml)
+- `.env` or `.env.test` exists if referenced in configs
+
+**Python services:**
+- Virtual environment exists (`.venv/`, `venv/`, or active conda env)
+- Dependencies installed (check for `requirements.txt`, `pyproject.toml` with deps)
+- Test dependencies present (pytest in installed packages)
+
+**Go services:**
+- `go.sum` exists (modules downloaded)
+- Build succeeds (`go build ./...`)
+
+**Java/Kotlin services:**
+- Build tool wrapper exists (`mvnw`, `gradlew`)
+- Dependencies cached (`~/.m2/repository` or `.gradle/`)
+
+**Integration/E2E prerequisites:**
+- Docker running (if docker-compose.yml or Dockerfile present in test config)
+- Test database available (check env vars like DATABASE_URL, TEST_DATABASE_URL)
+- Required services running (check ports or health endpoints if configured)
+
+Classify each service:
+
+- `ready` - all prerequisites met, tests can run immediately
+- `needs-setup` - missing prerequisites with specific fix commands
+- `blocked` - critical dependency missing that cannot be auto-resolved
+
+If a service is `needs-setup`, ask the user whether to run setup commands before continuing.
+
+### 4. Run Tests
+
+Execute tests in priority order (fastest first):
+
+1. **Unit tests** - timeout 5 minutes per service
+2. **Integration tests** - timeout 10 minutes per service
+3. **Component tests** - timeout 10 minutes per service
+4. **E2E tests** - timeout 15 minutes per service
+5. **Performance tests** - timeout 10 minutes per service
+
+Execution rules:
+
+- Within a service, run test types sequentially in the order above
+- Capture full stdout/stderr for each test run
+- Record exit code, duration, and any coverage output
+- If a test suite fails, continue with remaining suites in that service and other services
+- Pass `--no-color` or equivalent flag when available for clean output parsing
+- Use `--coverage` or equivalent when the runner supports it
+
+Common run commands by runner:
+
+| Runner | Command |
+|---|---|
+| Jest | `npx jest --ci --coverage --no-color` |
+| Vitest | `npx vitest run --coverage --reporter=verbose` |
+| pytest | `python -m pytest -v --tb=short --no-header` |
+| Playwright | `npx playwright test --reporter=list` |
+| Cypress | `npx cypress run --reporter spec` |
+| Mocha | `npx mocha --reporter spec --no-color` |
+| go test | `go test -v -count=1 ./...` |
+| Maven | `./mvnw test -B` |
+| Gradle | `./gradlew test` |
+| k6 | `k6 run --summary-trend-stats="avg,p(95),p(99)" <script>` |
+| Locust | `locust --headless -u 1 -r 1 --run-time 30s` |
+
+If `package.json` has specific named scripts (e.g., `test:unit`, `test:e2e`), prefer those over generic runner commands as they may include project-specific configuration.
+
+### 5. Collect and Parse Results
+
+For each test run, extract:
+
+- Total tests: passed / failed / skipped / errored
+- Duration in seconds
+- Coverage percentage (line, branch, function) if available
+- List of failed tests with:
+  - Test file path
+  - Test name / describe block
+  - Error message (first 10 lines)
+  - Stack trace hint (file:line of assertion failure)
+
+Aggregate results:
+
+- Per service: total pass/fail/skip across all test types
+- Per test type: total pass/fail/skip across all services
+- Overall: grand totals
+
+### 6. Generate Report
+
+Write the report to stdout using `references/test-report-template.md` as the structure.
+
+Include:
+
+- Executive summary with overall pass/fail status
+- Per-service breakdown
+- Failure details with actionable context
+- Environment issues encountered
+- Recommendations for improving test coverage
+
+## Parallel Execution Strategy
+
+When multiple services are affected:
+
+- Execute services sequentially (OpenCode does not support parallel subagent execution)
+- Within each service, run test types sequentially in priority order
+- Collect all results and assemble the final report after all services complete
+
+## Error Handling
+
+| Situation | Behavior |
+|---|---|
+| No git repository | Error: report and exit |
+| No changed files detected | Info: suggest `--all` flag or explicit paths |
+| No tests found in service | Warning: report service as "no tests configured" |
+| Test runner not installed | `needs-setup`: suggest install command |
+| Test timeout exceeded | Kill process, report as timeout failure |
+| Environment variable missing | `needs-setup`: list required vars |
+| Docker not running | `blocked` for integration/e2e that need it |
+
+## Output Contract
+
+Always produce a report using `references/test-report-template.md` structure containing:
+
+- Changed services detection summary
+- Environment readiness matrix
+- Test results matrix (service x test-type)
+- Failure details with file paths and error messages
+- Coverage summary per service (when available)
+- Actionable recommendations
+
+## Prompt Template
+
+Invoke the skill with optional arguments:
+
+```text
+/test-all $ARGUMENTS
+```
+
+Where `$ARGUMENTS` can be:
+
+- Empty: auto-detect changed services from git, use `main` as base branch
+- `--all`: run tests for all services
+- `--base-branch=develop`: use `develop` as comparison branch
+- `services/api services/web`: explicit service paths
+- Combinations: `services/api --base-branch=develop`
+
+Default user prompt after parsing arguments:
+
+```text
+Run all applicable tests for modified services in this monorepo.
+Detect which services changed, discover test types, validate the environment, execute tests, and produce a structured report.
+```

--- a/.opencode/skills/test-all/SKILL.md
+++ b/.opencode/skills/test-all/SKILL.md
@@ -48,6 +48,7 @@ Combine all changed file paths. Map each changed file to its parent service dire
 - `Cargo.toml` (Rust)
 - `Gemfile` (Ruby)
 - `composer.json` (PHP)
+- `*.csproj` or `*.sln` (.NET / C#)
 - `Makefile` with test targets (generic)
 
 If the repository root itself is a single-service project (manifest at root level), treat the entire repo as one service.
@@ -72,6 +73,7 @@ For each affected service, scan for test runner configurations and classify test
 | `k6/` scripts or `*.k6.js` | k6 | performance |
 | `locustfile.py` or `locust/` | Locust | performance |
 | `artillery.yml` or `.artillery/` | Artillery | performance |
+| `*.csproj` + `*Tests` project | dotnet test | unit |
 
 Additionally, check `package.json` scripts for named test commands:
 
@@ -102,8 +104,8 @@ Produce a matrix: service x test-type with runner commands.
 For each service, check prerequisites:
 
 **Node.js services:**
-- `node_modules/` exists -> if not, suggest `npm install` / `yarn install` / `pnpm install`
-- Check for lockfile to determine package manager (package-lock.json / yarn.lock / pnpm-lock.yaml)
+- `node_modules/` exists -> if not, suggest `npm install` / `yarn install` / `pnpm install` / `bun install`
+- Check for lockfile to determine package manager (package-lock.json / yarn.lock / pnpm-lock.yaml / bun.lock)
 - `.env` or `.env.test` exists if referenced in configs
 
 **Python services:**
@@ -113,11 +115,15 @@ For each service, check prerequisites:
 
 **Go services:**
 - `go.sum` exists (modules downloaded)
-- Build succeeds (`go build ./...`)
+- Source valid (`go vet ./...`)
 
 **Java/Kotlin services:**
 - Build tool wrapper exists (`mvnw`, `gradlew`)
 - Dependencies cached (`~/.m2/repository` or `.gradle/`)
+
+**.NET services:**
+- .NET SDK installed (`dotnet --version`)
+- Dependencies restored (`dotnet restore` if `obj/` missing)
 
 **Integration/E2E prerequisites:**
 - Docker running (if docker-compose.yml or Dockerfile present in test config)
@@ -157,7 +163,7 @@ Common run commands by runner:
 |---|---|
 | Jest | `npx jest --ci --coverage --no-color` |
 | Vitest | `npx vitest run --coverage --reporter=verbose` |
-| pytest | `python -m pytest -v --tb=short --no-header` |
+| pytest | `python -m pytest -v --tb=short --no-header --cov` |
 | Playwright | `npx playwright test --reporter=list` |
 | Cypress | `npx cypress run --reporter spec` |
 | Mocha | `npx mocha --reporter spec --no-color` |
@@ -166,6 +172,9 @@ Common run commands by runner:
 | Gradle | `./gradlew test` |
 | k6 | `k6 run --summary-trend-stats="avg,p(95),p(99)" <script>` |
 | Locust | `locust --headless -u 1 -r 1 --run-time 30s` |
+| dotnet test | `dotnet test --no-build --verbosity normal` |
+
+Note: `--no-header` requires pytest >= 7.0. For older versions, remove this flag from the command.
 
 If `package.json` has specific named scripts (e.g., `test:unit`, `test:e2e`), prefer those over generic runner commands as they may include project-specific configuration.
 

--- a/.opencode/skills/test-all/SKILL.md
+++ b/.opencode/skills/test-all/SKILL.md
@@ -140,7 +140,7 @@ If a service is `needs-setup`, ask the user whether to run setup commands before
 
 ### 4. Run Tests
 
-Execute tests in priority order (fastest first):
+Execute ALL test types discovered in Step 2. Run them in this order (fastest first), but never skip any type:
 
 1. **Unit tests** - timeout 5 minutes per service
 2. **Integration tests** - timeout 10 minutes per service
@@ -150,6 +150,7 @@ Execute tests in priority order (fastest first):
 
 Execution rules:
 
+- CRITICAL: run every test type from the Step 2 discovery matrix. Do not stop after unit or integration tests -- always continue through component, e2e, and performance tests
 - Within a service, run test types sequentially in the order above
 - Capture full stdout/stderr for each test run
 - Record exit code, duration, and any coverage output
@@ -196,6 +197,11 @@ Aggregate results:
 - Per service: total pass/fail/skip across all test types
 - Per test type: total pass/fail/skip across all services
 - Overall: grand totals
+
+Verify completeness:
+
+- Cross-reference executed test types against the Step 2 discovery matrix
+- If any discovered test type was not executed, flag it as "NOT RUN" in the report with explanation
 
 ### 6. Generate Report
 

--- a/.opencode/skills/test-all/SKILL.md
+++ b/.opencode/skills/test-all/SKILL.md
@@ -99,6 +99,29 @@ For Go projects, check for:
 
 Produce a matrix: service x test-type with runner commands.
 
+#### 2b. Discover Project-Specific Test Scripts
+
+Before falling back to standard runner commands, search each service for custom test scripts that the team may have configured. These take priority over generic commands because they often include project-specific flags, environment setup, or multi-step workflows.
+
+Search locations (in priority order):
+
+1. **Makefile / Taskfile.yml / justfile** -- look for targets like `test`, `test-unit`, `test-integration`, `test-e2e`, `test-perf`, `test-all`, `check`, `ci-test`
+2. **Shell scripts** -- `scripts/test*.sh`, `bin/test*`, `run-tests.sh`, `ci/*.sh`
+3. **package.json scripts** (Node.js) -- `test`, `test:unit`, `test:integration`, `test:e2e`, `test:perf`, `test:all`
+4. **pyproject.toml / tox.ini / noxfile.py** (Python) -- `[tool.tox]` envs, nox sessions like `tests`, `integration`, `e2e`
+5. **Docker Compose test services** -- `docker-compose.test.yml`, services named `*-test*`
+6. **CI config files** -- `.github/workflows/test*.yml`, `Jenkinsfile`, `.gitlab-ci.yml` -- extract test commands from CI steps as hints for local execution
+
+For each discovered script, map it to a test type (unit / integration / e2e / performance) based on name or content.
+
+**Command resolution priority** for each test type in a service:
+
+1. Project-specific script (Makefile target, shell script, tox env, etc.)
+2. Named `package.json` script (e.g., `test:e2e`)
+3. Standard runner command from the table in Step 4d
+
+Record the chosen command source in the execution queue (e.g., `Makefile:test-e2e` vs `npx playwright test`).
+
 ### 3. Validate Environment Readiness
 
 For each service, check prerequisites:
@@ -146,10 +169,10 @@ From the Step 2 discovery matrix, build an execution queue listing every service
 
 ```
 EXECUTION QUEUE (N entries):
-[ ] unit       - Jest (services/api), pytest (services/worker)
-[ ] integration - pytest (services/worker)
-[ ] e2e        - Playwright (services/web)
-[ ] performance - k6 (services/api)
+[ ] unit        - services/api (npm test:unit via package.json), services/worker (make test-unit via Makefile)
+[ ] integration - services/worker (python -m pytest tests/integration/ --cov, standard)
+[ ] e2e         - services/web (scripts/run-e2e.sh via shell script)
+[ ] performance - services/api (k6 run ..., standard)
 ```
 
 This queue is a binding contract. Every entry MUST be executed before generating the report.
@@ -213,7 +236,7 @@ CHECKPOINT: 2/4 complete, 2 remaining:
 
 Note: `--no-header` requires pytest >= 7.0. For older versions, remove this flag from the command.
 
-If `package.json` has specific named scripts (e.g., `test:unit`, `test:e2e`), prefer those over generic runner commands as they may include project-specific configuration.
+Use the command resolution priority from Step 2b: project-specific scripts first, then named package.json scripts, then standard runner commands from the table above.
 
 ### 5. Collect and Parse Results
 

--- a/.opencode/skills/test-all/SKILL.md
+++ b/.opencode/skills/test-all/SKILL.md
@@ -37,9 +37,11 @@ git diff --name-only <base-branch>...HEAD 2>/dev/null || true
 git diff --name-only
 # Staged changes
 git diff --name-only --cached
+# Untracked files (new files not yet staged)
+git ls-files --others --exclude-standard
 ```
 
-Combine all changed file paths. Map each changed file to its parent service directory. A service directory is identified by the presence of a project manifest at its root:
+Combine all changed file paths (including untracked). Map each changed file to its parent service directory. A service directory is identified by the presence of a project manifest at its root:
 
 - `package.json` (Node.js / frontend)
 - `pyproject.toml` or `setup.py` or `setup.cfg` (Python)
@@ -63,7 +65,7 @@ For each affected service, scan for test runner configurations and classify test
 |---|---|---|
 | `jest.config.*` or `jest` key in package.json | Jest | unit |
 | `vitest.config.*` | Vitest | unit |
-| `pytest.ini` / `pyproject.toml` with `[tool.pytest]` / `conftest.py` | pytest | unit |
+| `pytest.ini` / `pyproject.toml` with `[tool.pytest.ini_options]` / `conftest.py` | pytest | unit |
 | `playwright.config.*` | Playwright | e2e |
 | `cypress.config.*` or `cypress/` directory | Cypress | e2e |
 | `.mocharc.*` or `mocha` key in package.json | Mocha | unit |
@@ -223,7 +225,7 @@ CHECKPOINT: 2/4 complete, 2 remaining:
 |---|---|
 | Jest | `npx jest --ci --coverage --no-color` |
 | Vitest | `npx vitest run --coverage --reporter=verbose` |
-| pytest | `python -m pytest -v --tb=short --no-header --cov` |
+| pytest | `python -m pytest -v --tb=short --no-header` (add `--cov` only if pytest-cov is installed) |
 | Playwright | `npx playwright test --reporter=list` |
 | Cypress | `npx cypress run --reporter spec` |
 | Mocha | `npx mocha --reporter spec --no-color` |
@@ -234,7 +236,7 @@ CHECKPOINT: 2/4 complete, 2 remaining:
 | Locust | `locust --headless -u 1 -r 1 --run-time 30s` |
 | dotnet test | `dotnet test --no-build --verbosity normal` |
 
-Note: `--no-header` requires pytest >= 7.0. For older versions, remove this flag from the command.
+Note: `--no-header` requires pytest >= 7.0. For older versions, remove this flag. To check if pytest-cov is available, run `python -m pytest --co -q --cov 2>&1 | head -1` -- if it errors with "unrecognized arguments", omit `--cov`.
 
 Use the command resolution priority from Step 2b: project-specific scripts first, then named package.json scripts, then standard runner commands from the table above.
 

--- a/.opencode/skills/test-all/references/test-report-template.md
+++ b/.opencode/skills/test-all/references/test-report-template.md
@@ -1,0 +1,103 @@
+# Test Run Report
+
+Use this structure for the final output.
+
+## 1. Summary
+
+| Metric | Value |
+|---|---|
+| Services tested | N |
+| Test suites run | N |
+| Total tests | N |
+| Passed | N |
+| Failed | N |
+| Skipped | N |
+| Total duration | Nm Ns |
+| Overall status | PASS / FAIL |
+
+## 2. Changed Services
+
+| Service | Path | Changed Files | Detection Method |
+|---|---|---|---|
+| api-service | `services/api/` | 12 | git diff vs main |
+| web-app | `services/web/` | 5 | git diff vs main |
+
+Detection method values:
+- `git diff vs <branch>`
+- `explicit path`
+- `--all flag`
+
+## 3. Environment Readiness
+
+| Service | Status | Issues | Fix Commands |
+|---|---|---|---|
+| api-service | ready | - | - |
+| web-app | needs-setup | node_modules missing | `cd services/web && npm install` |
+
+Status values:
+- `ready` - all prerequisites met
+- `needs-setup` - fixable issues with listed commands
+- `blocked` - critical dependency missing
+
+## 4. Test Results Matrix
+
+| Service | Unit | Integration | Component | E2E | Performance |
+|---|---|---|---|---|---|
+| api-service | 45/45 pass | 12/14 pass | - | - | - |
+| web-app | 89/90 pass | - | 15/15 pass | 8/8 pass | - |
+
+Cell format: `passed/total status` or `-` if test type not present.
+
+## 5. Failure Details
+
+### Service: `<service-name>`
+
+#### Test Type: `<type>`
+
+**Runner:** `<runner-name>` | **Command:** `<command-used>`
+
+| # | Test | File | Error |
+|---|---|---|---|
+| 1 | should validate email format | `src/validators/__tests__/email.test.ts:42` | Expected "valid" but received "invalid" |
+| 2 | should handle timeout | `src/api/__tests__/client.test.ts:88` | Timeout of 5000ms exceeded |
+
+<details>
+<summary>Full error output for test #N</summary>
+
+```
+Paste relevant error output here (first 20 lines).
+```
+
+</details>
+
+Repeat for each failing test type and service.
+
+## 6. Coverage Summary
+
+| Service | Lines | Branches | Functions | Statements |
+|---|---|---|---|---|
+| api-service | 78.5% | 65.2% | 82.1% | 79.0% |
+| web-app | 91.2% | 87.4% | 93.5% | 90.8% |
+
+Note: coverage data is only available when the test runner supports it and `--coverage` flag was used.
+If coverage is not available for a service, note "N/A" and explain why.
+
+## 7. Recommendations
+
+List actionable items based on the test run results:
+
+- **Missing test types**: services without integration/e2e tests
+- **Low coverage areas**: files or modules below threshold
+- **Flaky tests**: tests that show intermittent behavior (if detected)
+- **Environment improvements**: CI configuration suggestions
+- **New test suggestions**: uncovered code paths in changed files
+
+Format each recommendation as:
+
+| Priority | Service | Recommendation | Rationale |
+|---|---|---|---|
+| high | api-service | Add integration tests for new endpoint | Endpoint `/api/v2/users` has no integration coverage |
+| medium | web-app | Fix flaky timeout test | `client.test.ts:88` failed with timeout |
+| low | web-app | Increase branch coverage | Branch coverage 65.2% is below 80% threshold |
+
+Priority values: `critical`, `high`, `medium`, `low`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,8 @@ code-agent-octopus/
 │   │   └── context-memory/     # /context-memory:add-memory
 │   ├── skills/                 # Skills (script-based and model-invocation)
 │   │   ├── worktree/           # Git worktree with config sync (script-based)
-│   │   └── jira-parallel-execution-planner/  # Jira delivery planning (model-invocation)
+│   │   ├── jira-parallel-execution-planner/  # Jira delivery planning (model-invocation)
+│   │   └── test-all/           # Test discovery and execution (model-invocation)
 │   └── settings.local.json     # Local config (gitignored)
 ├── .codex/
 │   └── commands/               # Codex CLI command mirrors (same as .claude/commands)
@@ -503,6 +504,7 @@ opencode
 @planning-implementation       # Invoke agent with @mention
 /jira-task-analyze PROJ-123    # Run command
 /worktree                      # Create git worktree with config sync
+/test-all                      # Run all tests for changed services
 ```
 
 ### Using Copilot CLI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,8 @@ code-agent-octopus/
 │   ├── skills/                 # Skills (script-based and model-invocation)
 │   │   ├── worktree/           # Git worktree with config sync (script-based)
 │   │   ├── jira-parallel-execution-planner/  # Jira delivery planning (model-invocation)
-│   │   └── protractor-playwright-migrator/  # Protractor-to-Playwright migration (model-invocation)
+│   │   ├── protractor-playwright-migrator/  # Protractor-to-Playwright migration (model-invocation)
+│   │   └── test-all/           # Test discovery and execution (model-invocation)
 │   └── settings.local.json     # Local config (gitignored)
 ├── .opencode/
 │   ├── agent/                  # OpenCode agents (flat structure, 19 total)
@@ -182,6 +183,7 @@ Instructions with dynamic features:
 - **`/worktree`** - Create git worktree with automatic gitignored files sync (configs, .env, IDE settings)
 - **`/jira-parallel-execution-planner`** - Analyze Jira task with linked issues, validate execution sequence and parallelization, assess codebase readiness, produce implementation + parallel subagent plans
 - **`/protractor-playwright-migrator`** - Migrate Creatio Protractor tests to Playwright TestKit with chrome-devtools verification
+- **`/test-all`** - Detect modified services, discover all test types, validate environment, run tests, produce structured report
 
 ### Key Workflows (Claude Code)
 
@@ -420,6 +422,7 @@ Skills are reusable instruction sets distributed across all supported CLI vendor
 | **`/worktree`** | Script-based | Create git worktree with automatic gitignored files sync |
 | **`/jira-parallel-execution-planner`** | Model-invocation | Analyze Jira task dependencies, validate parallelization, produce execution plans |
 | **`/protractor-playwright-migrator`** | Model-invocation | Migrate Protractor tests to Playwright TestKit with chrome-devtools verification |
+| **`/test-all`** | Model-invocation | Detect modified services, discover tests, run all suites, produce report |
 
 ### Skills Locations by Vendor
 


### PR DESCRIPTION
## Summary

- New model-invocation skill `/test-all` that automates test discovery and execution across multi-service repositories
- Detects modified services via git diff, discovers all test types (unit, integration, component, e2e, performance), validates environment readiness, runs tests in parallel, and produces a structured report
- Synced across all 5 CLI vendors: Claude Code, Factory, OpenCode, Codex, GitHub

## Files

- `SKILL.md` -- skill definition with 6-phase workflow (detect changes, discover tests, validate env, run, collect, report)
- `references/test-report-template.md` -- structured output template with summary, results matrix, failure details, coverage, recommendations
- `.codex/skills/test-all/agents/openai.yaml` -- Codex CLI interface metadata

## Test plan

- [x] Verify `/test-all` appears in Claude Code skill listing
- [x] Test on a repo with Node.js service (jest/vitest discovery)
- [x] Test on a repo with Python service (pytest discovery)
- [x] Test `--all` flag for full repo scan
- [x] Test explicit service path arguments
- [x] Test `--base-branch=develop` override
- [x] Verify report follows test-report-template.md structure